### PR TITLE
Read build-tools and android version from build.gradle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,6 @@ machine:
     GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError"'
 dependencies:
   pre:
-    - echo y | android update sdk --no-ui --all --filter build-tools-24.0.1
+    - echo y | android update sdk --no-ui --all --filter build-tools-`grep 'buildToolsVersion' groupie/build.gradle | grep -o '[0-9].*[0-9]'`
     - echo y | android update sdk --no-ui --filter extra-android-m2repository
-    - echo y | android update sdk --no-ui --filter android-24
+    - echo y | android update sdk --no-ui --filter android-`grep 'compileSdkVersion' groupie/build.gradle | grep -o '[0-9].*[0-9]'`


### PR DESCRIPTION
This will eliminate the problem of having to update the circle.yml every time the build tools version is bumped
