### PR TITLE
Fixed wrong item range removed notification.

### DIFF
--- a/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
+++ b/groupie/src/main/java/com/genius/groupie/GroupAdapter.java
@@ -180,9 +180,10 @@ public class GroupAdapter extends RecyclerView.Adapter<ViewHolder> implements Gr
         if (group == null) throw new RuntimeException("Group cannot be null");
         int position = groups.indexOf(group);
         int count = groups.get(position).getItemCount();
+        int itemCountBeforeGroup = getItemCountBeforeGroup(position);
         group.setGroupDataObserver(null);
         groups.remove(position);
-        notifyItemRangeRemoved(position, count);
+        notifyItemRangeRemoved(itemCountBeforeGroup, count);
     }
 
     public void add(@NonNull int index, Group group) {


### PR DESCRIPTION
Wrong behaviour of group adapter when deleting group, caused by using wrong position in notifyItemRangeRemoved method. Fixed with right position.