### PR TITLE
Adds support for item long click listeners

### DIFF
--- a/example/src/main/java/com/xwray/groupie/example/MainActivity.java
+++ b/example/src/main/java/com/xwray/groupie/example/MainActivity.java
@@ -14,11 +14,11 @@ import android.text.TextUtils;
 import android.view.View;
 import android.widget.Toast;
 
-import com.xwray.groupie.example.R;
 import com.xwray.groupie.ExpandableGroup;
 import com.xwray.groupie.GroupAdapter;
 import com.xwray.groupie.Item;
 import com.xwray.groupie.OnItemClickListener;
+import com.xwray.groupie.OnItemLongClickListener;
 import com.xwray.groupie.Section;
 import com.xwray.groupie.TouchCallback;
 import com.xwray.groupie.UpdatingGroup;
@@ -82,6 +82,7 @@ public class MainActivity extends AppCompatActivity {
 
         groupAdapter = new GroupAdapter();
         groupAdapter.setOnItemClickListener(onItemClickListener);
+        groupAdapter.setOnItemLongClickListener(onItemLongClickListener);
         groupAdapter.setSpanCount(12);
         populateAdapter();
         layoutManager = new GridLayoutManager(this, groupAdapter.getSpanCount());
@@ -232,6 +233,20 @@ public class MainActivity extends AppCompatActivity {
                     Toast.makeText(MainActivity.this, cardItem.getText(), Toast.LENGTH_SHORT).show();
                 }
             }
+        }
+    };
+
+    private OnItemLongClickListener onItemLongClickListener = new OnItemLongClickListener() {
+        @Override
+        public boolean onItemLongClick(Item item, View view) {
+            if (item instanceof CardItem) {
+                CardItem cardItem = (CardItem) item;
+                if (!TextUtils.isEmpty(cardItem.getText())) {
+                    Toast.makeText(MainActivity.this, "Long clicked: " + cardItem.getText(), Toast.LENGTH_SHORT).show();
+                    return true;
+                }
+            }
+            return false;
         }
     };
 

--- a/groupie/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/groupie/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -19,6 +19,7 @@ public class GroupAdapter extends RecyclerView.Adapter<ViewHolder> implements Gr
 
     private final List<Group> groups = new ArrayList<>();
     private OnItemClickListener onItemClickListener;
+    private OnItemLongClickListener onItemLongClickListener;
     private int spanCount = 1;
     
     private final GridLayoutManager.SpanSizeLookup spanSizeLookup = new GridLayoutManager.SpanSizeLookup() {
@@ -53,6 +54,15 @@ public class GroupAdapter extends RecyclerView.Adapter<ViewHolder> implements Gr
         this.onItemClickListener = onItemClickListener;
     }
 
+    /**
+     * Optionally register an {@link OnItemLongClickListener} that listens to long click at the root of
+     * each Item where {@link Item#isClickable()} returns true
+     * @param onItemLongClickListener The long click listener to set
+     */
+    public void setOnItemLongClickListener(OnItemLongClickListener onItemLongClickListener) {
+        this.onItemLongClickListener = onItemLongClickListener;
+    }
+
     @Override public ViewHolder<? extends ViewDataBinding> onCreateViewHolder(ViewGroup parent, int layoutResId) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());
         ViewDataBinding binding = DataBindingUtil.inflate(inflater, layoutResId, parent, false);
@@ -65,7 +75,7 @@ public class GroupAdapter extends RecyclerView.Adapter<ViewHolder> implements Gr
 
     @Override public void onBindViewHolder(ViewHolder holder, int position, List<Object> payloads) {
         Item contentItem = getItem(position);
-        contentItem.bind(holder, position, payloads, onItemClickListener);
+        contentItem.bind(holder, position, payloads, onItemClickListener, onItemLongClickListener);
     }
 
     @Override

--- a/groupie/src/main/java/com/xwray/groupie/Item.java
+++ b/groupie/src/main/java/com/xwray/groupie/Item.java
@@ -46,7 +46,21 @@ public abstract class Item<T extends ViewDataBinding> implements Group, SpanSize
      */
     @CallSuper
     public void bind(ViewHolder<T> holder, int position, List<Object> payloads, OnItemClickListener onItemClickListener) {
-        holder.bind(this, onItemClickListener);
+        bind(holder, position, payloads, onItemClickListener, null);
+    }
+
+    /**
+     * Perform any actions required to set up the view for display.
+     *
+     * @param holder              The viewholder to bind
+     * @param position            The adapter position
+     * @param payloads            Any payloads (this list may be empty)
+     * @param onItemClickListener An optional adapter-level click listener
+     * @param onItemLongClickListener An optional adapter-level long click listener
+     */
+    @CallSuper
+    public void bind(ViewHolder<T> holder, int position, List<Object> payloads, OnItemClickListener onItemClickListener, OnItemLongClickListener onItemLongClickListener) {
+        holder.bind(this, onItemClickListener, onItemLongClickListener);
         T binding = holder.binding;
 
         bind(binding, position, payloads);

--- a/groupie/src/main/java/com/xwray/groupie/OnItemLongClickListener.java
+++ b/groupie/src/main/java/com/xwray/groupie/OnItemLongClickListener.java
@@ -1,0 +1,9 @@
+package com.xwray.groupie;
+
+import android.view.View;
+
+public interface OnItemLongClickListener {
+
+    boolean onItemLongClick(Item item, View view);
+
+}

--- a/groupie/src/main/java/com/xwray/groupie/ViewHolder.java
+++ b/groupie/src/main/java/com/xwray/groupie/ViewHolder.java
@@ -12,6 +12,7 @@ public class ViewHolder<T extends ViewDataBinding> extends RecyclerView.ViewHold
     public final T binding;
     private Item item;
     private OnItemClickListener onItemClickListener;
+    private OnItemLongClickListener onItemLongClickListener;
 
     private View.OnClickListener onClickListener = new View.OnClickListener() {
         @Override
@@ -24,15 +25,27 @@ public class ViewHolder<T extends ViewDataBinding> extends RecyclerView.ViewHold
         }
     };
 
+    private View.OnLongClickListener onLongClickListener = new View.OnLongClickListener() {
+        @Override
+        public boolean onLongClick(View v) {
+            // Discard long click if the viewholder has been removed, but was still in the process of
+            // animating its removal while clicked (unlikely, but technically possible)
+            if (onItemLongClickListener != null && getAdapterPosition() != NO_POSITION) {
+                return onItemLongClickListener.onItemLongClick(getItem(), v);
+            }
+            return false;
+        }
+    };
+
     public ViewHolder(T binding) {
         super(binding.getRoot());
         this.binding = binding;
     }
 
-    public void bind(Item item, OnItemClickListener onItemClickListener) {
+    public void bind(Item item, OnItemClickListener onItemClickListener, OnItemLongClickListener onItemLongClickListener) {
         this.item = item;
 
-        // Only set the top-level click listener if a) the adapter has one, and b) the item has
+        // Only set the top-level click listeners if a) the adapter has one, and b) the item has
         // click enabled.  This ensures we don't interfere with user-set click listeners.
 
         // It would be nice to keep our listener always attached and set it only once on creating
@@ -41,6 +54,11 @@ public class ViewHolder<T extends ViewDataBinding> extends RecyclerView.ViewHold
         if (onItemClickListener != null && item.isClickable()) {
             binding.getRoot().setOnClickListener(onClickListener);
             this.onItemClickListener = onItemClickListener;
+        }
+
+        if (onItemLongClickListener != null && item.isClickable()) {
+            binding.getRoot().setOnLongClickListener(onLongClickListener);
+            this.onItemLongClickListener = onItemLongClickListener;
         }
     }
 


### PR DESCRIPTION
Maintains backwards compatibility by overloading Item#bind, and adding an optional long click listener parameter.