### PR TITLE
Change data binding dependencies to provided

### DIFF
--- a/groupie/build.gradle
+++ b/groupie/build.gradle
@@ -25,10 +25,6 @@ android {
     buildTypes {
     }
 
-    dataBinding {
-        enabled = true
-    }
-
     lintOptions {
         abortOnError false
     }
@@ -37,6 +33,12 @@ android {
 
 dependencies {
     compile 'com.android.support:recyclerview-v7:25.3.1'
+    provided ("com.android.databinding:library:1.3.1") {
+        transitive = false
+    }
+    provided ("com.android.databinding:baseLibrary:2.3.2") {
+        transitive = false
+    }
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
 }


### PR DESCRIPTION
This should resolve conflicts with using groupie in projects with
different build tools versions.