### PR TITLE
Show/hide empty carousel example (#86)

### DIFF
--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/CarouselGroup.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/CarouselGroup.java
@@ -1,0 +1,69 @@
+package com.xwray.groupie.example.databinding;
+
+import android.support.v7.widget.RecyclerView;
+
+import com.xwray.groupie.Group;
+import com.xwray.groupie.GroupAdapter;
+import com.xwray.groupie.GroupDataObserver;
+import com.xwray.groupie.Item;
+import com.xwray.groupie.example.databinding.item.CarouselItem;
+
+/**
+ * A group that contains a single carousel item and is empty when the carousel is empty
+ **/
+public class CarouselGroup implements Group {
+
+    private boolean isEmpty = true;
+    private RecyclerView.Adapter adapter;
+    private GroupDataObserver groupDataObserver;
+    private CarouselItem carouselItem;
+
+    private RecyclerView.AdapterDataObserver adapterDataObserver = new RecyclerView.AdapterDataObserver() {
+
+        @Override
+        public void onItemRangeRemoved(int positionStart, int itemCount) {
+            boolean empty = adapter.getItemCount() == 0;
+            if (empty && !isEmpty) {
+                isEmpty = empty;
+                groupDataObserver.onItemRemoved(carouselItem, 0);
+            }
+        }
+
+        @Override
+        public void onItemRangeInserted(int positionStart, int itemCount) {
+            boolean empty = adapter.getItemCount() == 0;
+            if (isEmpty && !empty) {
+                isEmpty = empty;
+                groupDataObserver.onItemInserted(carouselItem, 0);
+            }
+        }
+    };
+
+    public CarouselGroup(RecyclerView.ItemDecoration itemDecoration, GroupAdapter adapter) {
+        this.adapter = adapter;
+        carouselItem = new CarouselItem(itemDecoration, adapter);
+        isEmpty = adapter.getItemCount() == 0;
+        adapter.registerAdapterDataObserver(adapterDataObserver);
+    }
+
+    @Override
+    public int getItemCount() {
+        return isEmpty ? 0 : 1;
+    }
+
+    @Override
+    public Item getItem(int position) {
+        if (position == 0 && !isEmpty) return carouselItem;
+        else throw new IndexOutOfBoundsException();
+    }
+
+    @Override
+    public int getPosition(Item item) {
+        return item == carouselItem && !isEmpty ? 0 : -1;
+    }
+
+    @Override
+    public void setGroupDataObserver(GroupDataObserver groupDataObserver) {
+        this.groupDataObserver = groupDataObserver;
+    }
+}

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/MainActivity.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/MainActivity.java
@@ -15,6 +15,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.xwray.groupie.ExpandableGroup;
+import com.xwray.groupie.Group;
 import com.xwray.groupie.GroupAdapter;
 import com.xwray.groupie.Item;
 import com.xwray.groupie.OnItemClickListener;
@@ -31,7 +32,6 @@ import com.xwray.groupie.example.core.decoration.SwipeTouchCallback;
 import com.xwray.groupie.example.databinding.databinding.ActivityMainBinding;
 import com.xwray.groupie.example.databinding.item.CardItem;
 import com.xwray.groupie.example.databinding.item.CarouselCardItem;
-import com.xwray.groupie.example.databinding.item.CarouselItem;
 import com.xwray.groupie.example.databinding.item.ColumnItem;
 import com.xwray.groupie.example.databinding.item.FullBleedCardItem;
 import com.xwray.groupie.example.databinding.item.HeaderItem;
@@ -184,8 +184,9 @@ public class MainActivity extends AppCompatActivity {
 
         // Horizontal carousel
         Section carouselSection = new Section(new HeaderItem(R.string.carousel, R.string.carousel_subtitle));
-        CarouselItem carouselItem = makeCarouselItem();
-        carouselSection.add(carouselItem);
+        carouselSection.setHideWhenEmpty(true);
+        Group carousel = makeCarouselGroup();
+        carouselSection.add(carousel);
         groupAdapter.add(carouselSection);
 
         // Update with payload
@@ -214,15 +215,13 @@ public class MainActivity extends AppCompatActivity {
         return new ColumnGroup(columnItems);
     }
 
-    private CarouselItem makeCarouselItem() {
+    private Group makeCarouselGroup() {
         CarouselItemDecoration carouselDecoration = new CarouselItemDecoration(gray, betweenPadding);
         GroupAdapter carouselAdapter = new GroupAdapter();
-        for (int i = 0; i < 30; i++) {
-            carouselAdapter.add(new CarouselCardItem(rainbow200[7]));
+        for (int i = 0; i < 10; i++) {
+            carouselAdapter.add(new CarouselCardItem(rainbow200[i]));
         }
-        CarouselItem carouselItem = new CarouselItem(carouselDecoration);
-        carouselItem.setAdapter(carouselAdapter);
-        return carouselItem;
+        return new CarouselGroup(carouselDecoration, carouselAdapter);
     }
 
     private OnItemClickListener onItemClickListener = new OnItemClickListener() {

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselCardItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselCardItem.java
@@ -22,6 +22,6 @@ public class CarouselCardItem extends BindableItem<ItemSquareCardBinding> {
     }
 
     @Override public void bind(ItemSquareCardBinding viewBinding, int position) {
-        //viewBinding.getRoot().setBackgroundResource(colorRes);
+        viewBinding.getRoot().setBackgroundColor(colorRes);
     }
 }

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselItem.java
@@ -2,55 +2,49 @@ package com.xwray.groupie.example.databinding.item;
 
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
+import android.view.View;
 
+import com.xwray.groupie.GroupAdapter;
+import com.xwray.groupie.Item;
+import com.xwray.groupie.OnItemClickListener;
 import com.xwray.groupie.databinding.BindableItem;
+import com.xwray.groupie.databinding.ViewHolder;
 import com.xwray.groupie.example.databinding.R;
 import com.xwray.groupie.example.databinding.databinding.ItemCarouselBinding;
 
 /**
  * A horizontally scrolling RecyclerView, for use in a vertically scrolling RecyclerView.
  */
-public class CarouselItem extends BindableItem<ItemCarouselBinding> {
+public class CarouselItem extends BindableItem<ItemCarouselBinding> implements OnItemClickListener {
 
-    private RecyclerView.Adapter adapter;
-    private RecyclerView recyclerView;
+    private GroupAdapter adapter;
     private RecyclerView.ItemDecoration carouselDecoration;
-    private LinearLayoutManager layoutManager;
 
-    public CarouselItem(RecyclerView.ItemDecoration itemDecoration) {
+    public CarouselItem(RecyclerView.ItemDecoration itemDecoration, GroupAdapter adapter) {
         this.carouselDecoration = itemDecoration;
+        this.adapter = adapter;
+        adapter.setOnItemClickListener(this);
+    }
+
+    @Override
+    public ViewHolder<ItemCarouselBinding> createViewHolder(View itemView) {
+        ViewHolder<ItemCarouselBinding> viewHolder = super.createViewHolder(itemView);
+        RecyclerView recyclerView = viewHolder.binding.recyclerView;
+        recyclerView.addItemDecoration(carouselDecoration);
+        recyclerView.setLayoutManager(new LinearLayoutManager(recyclerView.getContext(), LinearLayoutManager.HORIZONTAL, false));
+        return viewHolder;
     }
 
     @Override public void bind(ItemCarouselBinding viewBinding, int position) {
-        recyclerView = viewBinding.recyclerView;
-        layoutManager = new LinearLayoutManager(recyclerView.getContext(), LinearLayoutManager.HORIZONTAL, false);
-        recyclerView.setLayoutManager(layoutManager);
-        recyclerView.setAdapter(adapter);
-
-        // We don't know if the layout we're passed has been bound before so
-        // we need to ensure we don't register the item decoration multiple times,
-        // by trying to remove it first. (Nothing happens if it's not registered.)
-        recyclerView.removeItemDecoration(carouselDecoration);
-        recyclerView.addItemDecoration(carouselDecoration);
+        viewBinding.recyclerView.setAdapter(adapter);
     }
 
     @Override public int getLayout() {
         return R.layout.item_carousel;
     }
 
-    public RecyclerView getRecyclerView() {
-        return recyclerView;
-    }
-
-    public RecyclerView.Adapter getAdapter() {
-        return adapter;
-    }
-
-    public void setAdapter(RecyclerView.Adapter adapter) {
-        this.adapter = adapter;
-    }
-
-    public LinearLayoutManager getLayoutManager() {
-        return layoutManager;
+    @Override
+    public void onItemClick(Item item, View view) {
+        adapter.remove(item);
     }
 }

--- a/example-databinding/src/main/res/layout/item_square_card.xml
+++ b/example-databinding/src/main/res/layout/item_square_card.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:tools="http://schemas.android.com/tools">
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="?android:attr/listPreferredItemHeightLarge"
@@ -9,13 +10,14 @@
         android:foreground="?android:attr/selectableItemBackground"
         android:orientation="vertical">
 
-        <TextView
-            android:id="@+id/text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+        <ImageView
+            app:srcCompat="@drawable/clear"
+            android:background="@drawable/ripple_circular"
+            android:padding="@dimen/padding_small"
+            android:duplicateParentState="true"
             android:layout_gravity="center"
-            android:textColor="?android:attr/textColorPrimary"
-            tools:text="This is text here"/>
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
 
     </FrameLayout>
 </layout>

--- a/example-shared/src/main/res/drawable/clear.xml
+++ b/example-shared/src/main/res/drawable/clear.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>
+</vector>


### PR DESCRIPTION
![sailfishn2g47olisa06142017001109](https://user-images.githubusercontent.com/1466033/27115082-48488fe2-5096-11e7-9f77-922acf496036.gif)

An example of a carousel group (horizontal RecyclerView) which hides itself when its carousel contents are empty.  

I was also able to refactor the original CarouselItem; much nicer with hooks to createViewHolder.

Honestly, this should be even easier.  And it will be when you can show/hide a Group. I hope this is a good demo in the meantime :)