### PR TITLE
Annotate everything with NonNull / Nullable for Kotlin (#94)

### DIFF
--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/CarouselGroup.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/CarouselGroup.java
@@ -1,5 +1,6 @@
 package com.xwray.groupie.example.databinding;
 
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 
 import com.xwray.groupie.Group;
@@ -51,6 +52,7 @@ public class CarouselGroup implements Group {
         return isEmpty ? 0 : 1;
     }
 
+    @NonNull
     @Override
     public Item getItem(int position) {
         if (position == 0 && !isEmpty) return carouselItem;
@@ -58,12 +60,17 @@ public class CarouselGroup implements Group {
     }
 
     @Override
-    public int getPosition(Item item) {
+    public int getPosition(@NonNull Item item) {
         return item == carouselItem && !isEmpty ? 0 : -1;
     }
 
     @Override
-    public void setGroupDataObserver(GroupDataObserver groupDataObserver) {
+    public void registerGroupDataObserver(@NonNull GroupDataObserver groupDataObserver) {
         this.groupDataObserver = groupDataObserver;
+    }
+
+    @Override
+    public void unregisterGroupDataObserver(@NonNull GroupDataObserver groupDataObserver) {
+        this.groupDataObserver = null;
     }
 }

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/ColumnGroup.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/ColumnGroup.java
@@ -1,5 +1,7 @@
 package com.xwray.groupie.example.databinding;
 
+import android.support.annotation.NonNull;
+
 import com.xwray.groupie.Group;
 import com.xwray.groupie.GroupDataObserver;
 import com.xwray.groupie.Item;
@@ -32,16 +34,24 @@ public class ColumnGroup implements Group {
         }
     }
 
-    public void setGroupDataObserver(GroupDataObserver groupDataObserver) {
+    @Override
+    public void registerGroupDataObserver(@NonNull GroupDataObserver groupDataObserver) {
         // no real need to do anything here
     }
 
+    @Override
+    public void unregisterGroupDataObserver(@NonNull GroupDataObserver groupDataObserver) {
+        // no real need to do anything here
+    }
+
+    @NonNull
+    @Override
     public BindableItem getItem(int position) {
         return items.get(position);
     }
 
     @Override
-    public int getPosition(Item item) {
+    public int getPosition(@NonNull Item item) {
         return items.indexOf(item);
     }
 

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/ExpandableHeaderItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/ExpandableHeaderItem.java
@@ -1,6 +1,7 @@
 package com.xwray.groupie.example.databinding;
 
 import android.graphics.drawable.Animatable;
+import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.view.View;
 
@@ -17,7 +18,7 @@ public class ExpandableHeaderItem extends HeaderItem implements ExpandableItem {
         super(titleStringResId, subtitleResId);
     }
 
-    @Override public void bind(final ItemHeaderBinding viewBinding, int position) {
+    @Override public void bind(@NonNull final ItemHeaderBinding viewBinding, int position) {
         super.bind(viewBinding, position);
 
         // Initial icon state -- not animated.
@@ -38,7 +39,7 @@ public class ExpandableHeaderItem extends HeaderItem implements ExpandableItem {
         drawable.start();
     }
 
-    @Override public void setExpandableGroup(ExpandableGroup onToggleListener) {
+    @Override public void setExpandableGroup(@NonNull ExpandableGroup onToggleListener) {
         this.expandableGroup = onToggleListener;
     }
 }

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CardItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CardItem.java
@@ -1,6 +1,7 @@
 package com.xwray.groupie.example.databinding.item;
 
 import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
 
 import com.xwray.groupie.databinding.BindableItem;
 import com.xwray.groupie.example.databinding.R;
@@ -28,7 +29,7 @@ public class CardItem extends BindableItem<ItemCardBinding> {
         return R.layout.item_card;
     }
 
-    @Override public void bind(ItemCardBinding viewBinding, int position) {
+    @Override public void bind(@NonNull ItemCardBinding viewBinding, int position) {
         //viewBinding.getRoot().setBackgroundColor(colorRes);
         viewBinding.text.setText(text);
     }

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselCardItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselCardItem.java
@@ -1,6 +1,7 @@
 package com.xwray.groupie.example.databinding.item;
 
 import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
 
 import com.xwray.groupie.databinding.BindableItem;
 import com.xwray.groupie.example.databinding.R;
@@ -21,7 +22,7 @@ public class CarouselCardItem extends BindableItem<ItemSquareCardBinding> {
         return R.layout.item_square_card;
     }
 
-    @Override public void bind(ItemSquareCardBinding viewBinding, int position) {
+    @Override public void bind(@NonNull ItemSquareCardBinding viewBinding, int position) {
         viewBinding.getRoot().setBackgroundColor(colorRes);
     }
 }

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselItem.java
@@ -1,5 +1,6 @@
 package com.xwray.groupie.example.databinding.item;
 
+import android.support.annotation.NonNull;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
@@ -27,7 +28,7 @@ public class CarouselItem extends BindableItem<ItemCarouselBinding> implements O
     }
 
     @Override
-    public ViewHolder<ItemCarouselBinding> createViewHolder(View itemView) {
+    public ViewHolder<ItemCarouselBinding> createViewHolder(@NonNull View itemView) {
         ViewHolder<ItemCarouselBinding> viewHolder = super.createViewHolder(itemView);
         RecyclerView recyclerView = viewHolder.binding.recyclerView;
         recyclerView.addItemDecoration(carouselDecoration);
@@ -35,7 +36,7 @@ public class CarouselItem extends BindableItem<ItemCarouselBinding> implements O
         return viewHolder;
     }
 
-    @Override public void bind(ItemCarouselBinding viewBinding, int position) {
+    @Override public void bind(@NonNull ItemCarouselBinding viewBinding, int position) {
         viewBinding.recyclerView.setAdapter(adapter);
     }
 

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/HeaderItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/HeaderItem.java
@@ -1,6 +1,7 @@
 package com.xwray.groupie.example.databinding.item;
 
 import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
 import android.support.annotation.StringRes;
 import android.view.View;
 
@@ -34,7 +35,7 @@ public class HeaderItem extends BindableItem<ItemHeaderBinding> {
         return R.layout.item_header;
     }
 
-    @Override public void bind(ItemHeaderBinding viewBinding, int position) {
+    @Override public void bind(@NonNull ItemHeaderBinding viewBinding, int position) {
         viewBinding.title.setText(titleStringResId);
         if (subtitleResId > 0) {
             viewBinding.subtitle.setText(subtitleResId);

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/HeartCardItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/HeartCardItem.java
@@ -2,6 +2,7 @@ package com.xwray.groupie.example.databinding.item;
 
 import android.graphics.drawable.Animatable;
 import android.support.annotation.ColorInt;
+import android.support.annotation.NonNull;
 import android.view.View;
 
 import com.xwray.groupie.databinding.BindableItem;
@@ -33,7 +34,7 @@ public class HeartCardItem extends BindableItem<ItemHeartCardBinding> {
     }
 
     @Override
-    public void bind(final ItemHeartCardBinding binding, int position) {
+    public void bind(@NonNull final ItemHeartCardBinding binding, int position) {
         //binding.getRoot().setBackgroundColor(colorRes);
         bindHeart(binding);
         binding.text.setText(String.valueOf(getId() + 1));
@@ -69,7 +70,7 @@ public class HeartCardItem extends BindableItem<ItemHeartCardBinding> {
     }
 
     @Override
-    public void bind(ItemHeartCardBinding binding, int position, List<Object> payloads) {
+    public void bind(@NonNull ItemHeartCardBinding binding, int position, List<Object> payloads) {
         if (payloads.contains(FAVORITE)) {
             bindHeart(binding);
         } else {

--- a/example/src/main/java/com/xwray/groupie/example/ColumnGroup.kt
+++ b/example/src/main/java/com/xwray/groupie/example/ColumnGroup.kt
@@ -29,8 +29,12 @@ class ColumnGroup(items: List<Item<*>>) : Group {
         }
     }
 
-    override fun setGroupDataObserver(groupDataObserver: GroupDataObserver) {
-        // no real need to do anything here
+    override fun registerGroupDataObserver(groupDataObserver: GroupDataObserver) {
+        // no need to do anything here
+    }
+
+    override fun unregisterGroupDataObserver(groupDataObserver: GroupDataObserver) {
+        // no need to do anything here
     }
 
     override fun getItem(position: Int): Item<*> {

--- a/library-databinding/src/main/java/com/xwray/groupie/databinding/BindableItem.java
+++ b/library-databinding/src/main/java/com/xwray/groupie/databinding/BindableItem.java
@@ -3,6 +3,7 @@ package com.xwray.groupie.databinding;
 import android.databinding.DataBindingUtil;
 import android.databinding.ViewDataBinding;
 import android.support.annotation.CallSuper;
+import android.support.annotation.NonNull;
 import android.view.View;
 
 import com.xwray.groupie.Item;
@@ -32,8 +33,9 @@ public abstract class BindableItem<T extends ViewDataBinding> extends Item<ViewH
         super(id);
     }
 
+    @NonNull
     @Override
-    public ViewHolder<T> createViewHolder(View itemView) {
+    public ViewHolder<T> createViewHolder(@NonNull View itemView) {
         T viewDataBinding = DataBindingUtil.bind(itemView);
         return new ViewHolder<>(viewDataBinding);
     }
@@ -49,18 +51,18 @@ public abstract class BindableItem<T extends ViewDataBinding> extends Item<ViewH
      */
     @CallSuper
     @Override
-    public void bind(ViewHolder<T> holder, int position, List<Object> payloads, OnItemClickListener onItemClickListener, OnItemLongClickListener onItemLongClickListener) {
+    public void bind(@NonNull ViewHolder<T> holder, int position, @NonNull List<Object> payloads, OnItemClickListener onItemClickListener, OnItemLongClickListener onItemLongClickListener) {
         super.bind(holder, position, payloads, onItemClickListener, onItemLongClickListener);
         holder.binding.executePendingBindings();
     }
 
     @Override
-    public void bind(ViewHolder<T> viewHolder, int position) {
+    public void bind(@NonNull ViewHolder<T> viewHolder, int position) {
         throw new RuntimeException("Doesn't get called");
     }
 
     @Override
-    public void bind(ViewHolder<T> holder, int position, List<Object> payloads) {
+    public void bind(@NonNull ViewHolder<T> holder, int position, @NonNull List<Object> payloads) {
         bind(holder.binding, position, payloads);
     }
 
@@ -70,7 +72,7 @@ public abstract class BindableItem<T extends ViewDataBinding> extends Item<ViewH
      * @param viewBinding The ViewDataBinding to bind
      * @param position The adapter position
      */
-    public abstract void bind(T viewBinding, int position);
+    public abstract void bind(@NonNull T viewBinding, int position);
 
     /**
      * Perform any actions required to set up the view for display.
@@ -82,8 +84,7 @@ public abstract class BindableItem<T extends ViewDataBinding> extends Item<ViewH
      * @param position The adapter position
      * @param payloads A list of payloads (may be empty)
      */
-    public void bind(T viewBinding, int position, List<Object> payloads) {
+    public void bind(@NonNull T viewBinding, int position, List<Object> payloads) {
         bind(viewBinding, position);
     }
-
 }

--- a/library-databinding/src/main/java/com/xwray/groupie/databinding/ViewHolder.java
+++ b/library-databinding/src/main/java/com/xwray/groupie/databinding/ViewHolder.java
@@ -1,11 +1,12 @@
 package com.xwray.groupie.databinding;
 
 import android.databinding.ViewDataBinding;
+import android.support.annotation.NonNull;
 
 public class ViewHolder<T extends ViewDataBinding> extends com.xwray.groupie.ViewHolder {
     public final T binding;
 
-    public ViewHolder(T binding) {
+    public ViewHolder(@NonNull T binding) {
         super(binding.getRoot());
         this.binding = binding;
     }

--- a/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
+++ b/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
@@ -1,5 +1,7 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,7 +21,7 @@ public class ExpandableGroup extends NestedGroup {
         ((ExpandableItem) expandableItem).setExpandableGroup(this);
     }
 
-    @Override public void add(Group group) {
+    @Override public void add(@NonNull Group group) {
         super.add(group);
         if (isExpanded) {
             int itemCount = getItemCount();
@@ -34,6 +36,7 @@ public class ExpandableGroup extends NestedGroup {
         return isExpanded;
     }
 
+    @NonNull
     public Group getGroup(int position) {
         if (position == 0) {
             return parent;
@@ -42,7 +45,7 @@ public class ExpandableGroup extends NestedGroup {
         }
     }
 
-    @Override public int getPosition(Group group) {
+    @Override public int getPosition(@NonNull Group group) {
         if (group == parent) {
             return 0;
         } else {
@@ -70,63 +73,63 @@ public class ExpandableGroup extends NestedGroup {
     }
 
     @Override
-    public void onChanged(Group group) {
+    public void onChanged(@NonNull Group group) {
         if (dispatchChildChanges(group)) {
             super.onChanged(group);
         }
     }
 
     @Override
-    public void onItemInserted(Group group, int position) {
+    public void onItemInserted(@NonNull Group group, int position) {
         if (dispatchChildChanges(group)) {
             super.onItemInserted(group, position);
         }
     }
 
     @Override
-    public void onItemChanged(Group group, int position) {
+    public void onItemChanged(@NonNull Group group, int position) {
         if (dispatchChildChanges(group)) {
             super.onItemChanged(group, position);
         }
     }
 
     @Override
-    public void onItemChanged(Group group, int position, Object payload) {
+    public void onItemChanged(@NonNull Group group, int position, Object payload) {
         if (dispatchChildChanges(group)) {
             super.onItemChanged(group, position, payload);
         }
     }
 
     @Override
-    public void onItemRemoved(Group group, int position) {
+    public void onItemRemoved(@NonNull Group group, int position) {
         if (dispatchChildChanges(group)) {
             super.onItemRemoved(group, position);
         }
     }
 
     @Override
-    public void onItemRangeChanged(Group group, int positionStart, int itemCount) {
+    public void onItemRangeChanged(@NonNull Group group, int positionStart, int itemCount) {
         if (dispatchChildChanges(group)) {
             super.onItemRangeChanged(group, positionStart, itemCount);
         }
     }
 
     @Override
-    public void onItemRangeInserted(Group group, int positionStart, int itemCount) {
+    public void onItemRangeInserted(@NonNull Group group, int positionStart, int itemCount) {
         if (dispatchChildChanges(group)) {
             super.onItemRangeInserted(group, positionStart, itemCount);
         }
     }
 
     @Override
-    public void onItemRangeRemoved(Group group, int positionStart, int itemCount) {
+    public void onItemRangeRemoved(@NonNull Group group, int positionStart, int itemCount) {
         if (dispatchChildChanges(group)) {
             super.onItemRangeRemoved(group, positionStart, itemCount);
         }
     }
 
     @Override
-    public void onItemMoved(Group group, int fromPosition, int toPosition) {
+    public void onItemMoved(@NonNull Group group, int fromPosition, int toPosition) {
         if (dispatchChildChanges(group)) {
             super.onItemMoved(group, fromPosition, toPosition);
         }

--- a/library/src/main/java/com/xwray/groupie/ExpandableItem.java
+++ b/library/src/main/java/com/xwray/groupie/ExpandableItem.java
@@ -1,5 +1,7 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
+
 /**
  * The "collapsed"/header item of an expanded group.  Some part (or all) of it is a "toggle" to
  * expand the group.
@@ -15,5 +17,5 @@ package com.xwray.groupie;
  *
  */
 public interface ExpandableItem {
-    void setExpandableGroup(ExpandableGroup onToggleListener);
+    void setExpandableGroup(@NonNull ExpandableGroup onToggleListener);
 }

--- a/library/src/main/java/com/xwray/groupie/Group.java
+++ b/library/src/main/java/com/xwray/groupie/Group.java
@@ -1,5 +1,7 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
+
 /**
  * A group of items, to be used in an adapter.
  */
@@ -7,15 +9,17 @@ public interface Group {
 
     int getItemCount();
 
-    Item getItem(int position);
+    @NonNull Item getItem(int position);
 
     /**
      * Gets the position of a
      * @param item
      * @return
      */
-    int getPosition(Item item);
+    int getPosition(@NonNull Item item);
 
-    void setGroupDataObserver(GroupDataObserver groupDataObserver);
+    void registerGroupDataObserver(@NonNull GroupDataObserver groupDataObserver);
+
+    void unregisterGroupDataObserver(@NonNull GroupDataObserver groupDataObserver);
 
 }

--- a/library/src/main/java/com/xwray/groupie/GroupDataObserver.java
+++ b/library/src/main/java/com/xwray/groupie/GroupDataObserver.java
@@ -1,21 +1,23 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
+
 public interface GroupDataObserver {
-    void onChanged(Group group);
+    void onChanged(@NonNull Group group);
 
-    void onItemInserted(Group group, int position);
+    void onItemInserted(@NonNull Group group, int position);
 
-    void onItemChanged(Group group, int position);
+    void onItemChanged(@NonNull Group group, int position);
 
-    void onItemChanged(Group group, int position, Object payload);
+    void onItemChanged(@NonNull Group group, int position, Object payload);
 
-    void onItemRemoved(Group group, int position);
+    void onItemRemoved(@NonNull Group group, int position);
 
-    void onItemRangeChanged(Group group, int positionStart, int itemCount);
+    void onItemRangeChanged(@NonNull Group group, int positionStart, int itemCount);
 
-    void onItemRangeInserted(Group group, int positionStart, int itemCount);
+    void onItemRangeInserted(@NonNull Group group, int positionStart, int itemCount);
 
-    void onItemRangeRemoved(Group group, int positionStart, int itemCount);
+    void onItemRangeRemoved(@NonNull Group group, int positionStart, int itemCount);
 
-    void onItemMoved(Group group, int fromPosition, int toPosition);
+    void onItemMoved(@NonNull Group group, int fromPosition, int toPosition);
 }

--- a/library/src/main/java/com/xwray/groupie/Item.java
+++ b/library/src/main/java/com/xwray/groupie/Item.java
@@ -2,6 +2,8 @@ package com.xwray.groupie;
 
 import android.support.annotation.CallSuper;
 import android.support.annotation.LayoutRes;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
@@ -25,7 +27,8 @@ public abstract class Item<VH extends ViewHolder> implements Group, SpanSizeProv
         this.id = id;
     }
 
-    public VH createViewHolder(View itemView) {
+    @NonNull
+    public VH createViewHolder(@NonNull View itemView) {
         return (VH) new ViewHolder(itemView);
     }
 
@@ -39,12 +42,14 @@ public abstract class Item<VH extends ViewHolder> implements Group, SpanSizeProv
      * @param onItemLongClickListener An optional adapter-level long click listener
      */
     @CallSuper
-    public void bind(VH holder, int position, List<Object> payloads, OnItemClickListener onItemClickListener, OnItemLongClickListener onItemLongClickListener) {
+    public void bind(@NonNull VH holder, int position, @NonNull List<Object> payloads,
+                     @Nullable OnItemClickListener onItemClickListener,
+                     @Nullable OnItemLongClickListener onItemLongClickListener) {
         holder.bind(this, onItemClickListener, onItemLongClickListener);
         bind(holder, position, payloads);
     }
 
-    public abstract void bind(VH viewHolder, int position);
+    public abstract void bind(@NonNull VH viewHolder, int position);
 
     /**
      * If you don't specify how to handle payloads in your implementation, they'll be ignored and
@@ -54,7 +59,7 @@ public abstract class Item<VH extends ViewHolder> implements Group, SpanSizeProv
      * @param position The adapter position
      * @param payloads A list of payloads (may be empty)
      */
-    public void bind(VH holder, int position, List<Object> payloads) {
+    public void bind(@NonNull VH holder, int position, @NonNull List<Object> payloads) {
         bind(holder, position);
     }
 
@@ -64,7 +69,7 @@ public abstract class Item<VH extends ViewHolder> implements Group, SpanSizeProv
      * @param holder The ViewHolder being recycled
      */
     @CallSuper
-    public void unbind(VH holder) {
+    public void unbind(@NonNull VH holder) {
         holder.unbind();
     }
 
@@ -92,9 +97,8 @@ public abstract class Item<VH extends ViewHolder> implements Group, SpanSizeProv
         return 0;
     }
 
-    public abstract
     @LayoutRes
-    int getLayout();
+    public abstract int getLayout();
 
     @Override
     public int getItemCount() {
@@ -102,17 +106,28 @@ public abstract class Item<VH extends ViewHolder> implements Group, SpanSizeProv
     }
 
     @Override
+    @NonNull
     public Item getItem(int position) {
-        return this;
+        if (position == 0) {
+            return this;
+        } else {
+            throw new IndexOutOfBoundsException("Wanted item at position " + position + " but" +
+                    " an Item is a Group of size 1");
+        }
     }
 
     @Override
-    public void setGroupDataObserver(GroupDataObserver groupDataObserver) {
+    public void registerGroupDataObserver(@NonNull GroupDataObserver groupDataObserver) {
         this.parentDataObserver = groupDataObserver;
     }
 
     @Override
-    public int getPosition(Item item) {
+    public void unregisterGroupDataObserver(@NonNull GroupDataObserver groupDataObserver) {
+        parentDataObserver = null;
+    }
+
+    @Override
+    public int getPosition(@NonNull Item item) {
         return this == item ? 0 : -1;
     }
 
@@ -130,7 +145,7 @@ public abstract class Item<VH extends ViewHolder> implements Group, SpanSizeProv
         }
     }
 
-    public void notifyChanged(Object payload) {
+    public void notifyChanged(@Nullable Object payload) {
         if (parentDataObserver != null) {
             parentDataObserver.onItemChanged(this, 0, payload);
         }

--- a/library/src/main/java/com/xwray/groupie/OnItemClickListener.java
+++ b/library/src/main/java/com/xwray/groupie/OnItemClickListener.java
@@ -1,9 +1,10 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
 import android.view.View;
 
 public interface OnItemClickListener {
 
-    void onItemClick(Item item, View view);
+    void onItemClick(@NonNull Item item, @NonNull View view);
 
 }

--- a/library/src/main/java/com/xwray/groupie/OnItemLongClickListener.java
+++ b/library/src/main/java/com/xwray/groupie/OnItemLongClickListener.java
@@ -1,9 +1,10 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
 import android.view.View;
 
 public interface OnItemLongClickListener {
 
-    boolean onItemLongClick(Item item, View view);
+    boolean onItemLongClick(@NonNull Item item, @NonNull View view);
 
 }

--- a/library/src/main/java/com/xwray/groupie/Section.java
+++ b/library/src/main/java/com/xwray/groupie/Section.java
@@ -5,7 +5,6 @@ import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 /**
  * A group which has a list of contents and an optional header and footer.
@@ -13,34 +12,40 @@ import java.util.List;
 public class Section extends NestedGroup {
     @Nullable
     private Group header;
+
     @Nullable
     private Group footer;
+
     @Nullable
     private Group placeholder;
+
     private final ArrayList<Group> children = new ArrayList<>();
+
     private boolean hideWhenEmpty = false;
+
     private boolean isHeaderAndFooterVisible = true;
+
     private boolean isPlaceholderVisible = false;
 
     public Section() {
         this(null, new ArrayList<Group>());
     }
 
-    public Section(Group header) {
+    public Section(@Nullable Group header) {
         this(header, new ArrayList<Group>());
     }
 
-    public Section(List<? extends Group> children) {
+    public Section(@NonNull Collection<? extends Group> children) {
         this(null, children);
     }
 
-    public Section(@Nullable Group header, Collection<? extends Group> children) {
+    public Section(@Nullable Group header, @NonNull Collection<? extends Group> children) {
         this.header = header;
         addAll(children);
     }
 
     @Override
-    public void add(int position, Group group) {
+    public void add(int position, @NonNull Group group) {
         super.add(position, group);
         children.add(position, group);
         final int notifyPosition = getHeaderItemCount() + getItemCount(children.subList(0, position));
@@ -49,7 +54,7 @@ public class Section extends NestedGroup {
     }
 
     @Override
-    public void addAll(Collection<? extends Group> groups) {
+    public void addAll(@NonNull Collection<? extends Group> groups) {
         if (groups.isEmpty()) return;
         super.addAll(groups);
         int position = getItemCountWithoutFooter();
@@ -59,7 +64,7 @@ public class Section extends NestedGroup {
     }
 
     @Override
-    public void addAll(int position, List<? extends Group> groups) {
+    public void addAll(int position, @NonNull Collection<? extends Group> groups) {
         if (groups.isEmpty()) {
             return;
         }
@@ -73,7 +78,7 @@ public class Section extends NestedGroup {
     }
 
     @Override
-    public void add(Group group) {
+    public void add(@NonNull Group group) {
         super.add(group);
         int position = getItemCountWithoutFooter();
         children.add(group);
@@ -82,7 +87,7 @@ public class Section extends NestedGroup {
     }
 
     @Override
-    public void remove(Group group) {
+    public void remove(@NonNull Group group) {
         super.remove(group);
         int position = getItemCountBeforeGroup(group);
         children.remove(group);
@@ -91,7 +96,7 @@ public class Section extends NestedGroup {
     }
 
     @Override
-    public void removeAll(List<? extends Group> groups) {
+    public void removeAll(@NonNull Collection<? extends Group> groups) {
         if (groups.isEmpty()) {
             return;
         }
@@ -207,6 +212,7 @@ public class Section extends NestedGroup {
     }
 
     @Override
+    @NonNull
     public Group getGroup(int position) {
         if (isHeaderShown() && position == 0) return header;
         position -= getHeaderCount();
@@ -216,7 +222,8 @@ public class Section extends NestedGroup {
             if (isFooterShown()) {
                 return footer;
             } else {
-                return null;
+                throw new IndexOutOfBoundsException("Wanted group at position " + position +
+                        " but there are only " + getGroupCount() + " groups");
             }
         } else {
             return children.get(position);
@@ -229,7 +236,7 @@ public class Section extends NestedGroup {
     }
 
     @Override
-    public int getPosition(Group group) {
+    public int getPosition(@NonNull Group group) {
         int count = 0;
         if (isHeaderShown()) {
             if (group == header) return count;
@@ -321,25 +328,25 @@ public class Section extends NestedGroup {
     }
 
     @Override
-    public void onItemInserted(Group group, int position) {
+    public void onItemInserted(@NonNull Group group, int position) {
         super.onItemInserted(group, position);
         refreshEmptyState();
     }
 
     @Override
-    public void onItemRemoved(Group group, int position) {
+    public void onItemRemoved(@NonNull Group group, int position) {
         super.onItemRemoved(group, position);
         refreshEmptyState();
     }
 
     @Override
-    public void onItemRangeInserted(Group group, int positionStart, int itemCount) {
+    public void onItemRangeInserted(@NonNull Group group, int positionStart, int itemCount) {
         super.onItemRangeInserted(group, positionStart, itemCount);
         refreshEmptyState();
     }
 
     @Override
-    public void onItemRangeRemoved(Group group, int positionStart, int itemCount) {
+    public void onItemRangeRemoved(@NonNull Group group, int positionStart, int itemCount) {
         super.onItemRangeRemoved(group, positionStart, itemCount);
         refreshEmptyState();
     }

--- a/library/src/main/java/com/xwray/groupie/TouchCallback.java
+++ b/library/src/main/java/com/xwray/groupie/TouchCallback.java
@@ -1,5 +1,6 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.helper.ItemTouchHelper;
 
@@ -9,11 +10,11 @@ public abstract class TouchCallback extends ItemTouchHelper.SimpleCallback {
         super(0, 0);
     }
 
-    @Override public int getSwipeDirs(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
+    @Override public int getSwipeDirs(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder) {
         return ((ViewHolder) viewHolder).getSwipeDirs();
     }
 
-    @Override public int getDragDirs(RecyclerView recyclerView, RecyclerView.ViewHolder viewHolder) {
+    @Override public int getDragDirs(@NonNull RecyclerView recyclerView, @NonNull RecyclerView.ViewHolder viewHolder) {
         return ((ViewHolder) viewHolder).getDragDirs();
     }
 }

--- a/library/src/main/java/com/xwray/groupie/UpdatingGroup.java
+++ b/library/src/main/java/com/xwray/groupie/UpdatingGroup.java
@@ -1,5 +1,6 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
 import android.support.v7.util.DiffUtil;
 import android.support.v7.util.ListUpdateCallback;
 
@@ -10,36 +11,40 @@ import java.util.List;
  * A group which accepts a list of items and diffs them against its previous contents,
  * generating the correct remove, add, move and change notifications to its parent observer,
  * to create an animated item-level update.
- *
+ * <p>
  * Item comparisons are made using:
  * - Item.getId() (are items the same?)
  * - Item.equals() (are contents the same?)
  * If you don't customize getId() or equals(), the default implementations will return false,
- * meaning your Group will consider every update a complete change of everything.  
+ * meaning your Group will consider every update a complete change of everything.
  */
 public class UpdatingGroup extends NestedGroup {
 
     private ListUpdateCallback listUpdateCallback = new ListUpdateCallback() {
-        @Override public void onInserted(int position, int count) {
+        @Override
+        public void onInserted(int position, int count) {
             notifyItemRangeInserted(position, count);
         }
 
-        @Override public void onRemoved(int position, int count) {
+        @Override
+        public void onRemoved(int position, int count) {
             notifyItemRangeRemoved(position, count);
         }
 
-        @Override public void onMoved(int fromPosition, int toPosition) {
+        @Override
+        public void onMoved(int fromPosition, int toPosition) {
             notifyItemMoved(fromPosition, toPosition);
         }
 
-        @Override public void onChanged(int position, int count, Object payload) {
+        @Override
+        public void onChanged(int position, int count, Object payload) {
             notifyItemRangeChanged(position, count);
         }
     };
 
     private List<Item> items = new ArrayList<>();
 
-    public void update(List<? extends Item> newItems) {
+    public void update(@NonNull List<? extends Item> newItems) {
         DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(new UpdatingCallback(newItems));
         super.removeAll(items);
         items.clear();
@@ -48,15 +53,19 @@ public class UpdatingGroup extends NestedGroup {
         diffResult.dispatchUpdatesTo(listUpdateCallback);
     }
 
-    @Override public Group getGroup(int position) {
+    @Override
+    @NonNull
+    public Group getGroup(int position) {
         return items.get(position);
     }
 
-    @Override public int getGroupCount() {
+    @Override
+    public int getGroupCount() {
         return items.size();
     }
 
-    @Override public int getPosition(Group group) {
+    @Override
+    public int getPosition(@NonNull Group group) {
         if (group instanceof Item) {
             return items.indexOf(group);
         } else {
@@ -72,15 +81,18 @@ public class UpdatingGroup extends NestedGroup {
             this.newList = newList;
         }
 
-        @Override public int getOldListSize() {
+        @Override
+        public int getOldListSize() {
             return items.size();
         }
 
-        @Override public int getNewListSize() {
+        @Override
+        public int getNewListSize() {
             return newList.size();
         }
 
-        @Override public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
+        @Override
+        public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
             Item oldItem = items.get(oldItemPosition);
             Item newItem = newList.get(newItemPosition);
             if (oldItem.getLayout() != newItem.getLayout()) {
@@ -89,7 +101,8 @@ public class UpdatingGroup extends NestedGroup {
             return oldItem.getId() == newItem.getId();
         }
 
-        @Override public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
+        @Override
+        public boolean areContentsTheSame(int oldItemPosition, int newItemPosition) {
             Item oldItem = items.get(oldItemPosition);
             Item newItem = newList.get(newItemPosition);
             return oldItem.equals(newItem);

--- a/library/src/main/java/com/xwray/groupie/ViewHolder.java
+++ b/library/src/main/java/com/xwray/groupie/ViewHolder.java
@@ -1,5 +1,7 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
 
@@ -9,11 +11,10 @@ public class ViewHolder extends RecyclerView.ViewHolder {
     private Item item;
     private OnItemClickListener onItemClickListener;
     private OnItemLongClickListener onItemLongClickListener;
-    private View rootView;
 
     private View.OnClickListener onClickListener = new View.OnClickListener() {
         @Override
-        public void onClick(View v) {
+        public void onClick(@NonNull View v) {
             // Discard click if the viewholder has been removed, but was still in the process of
             // animating its removal while clicked (unlikely, but technically possible)
             if (onItemClickListener != null && getAdapterPosition() != RecyclerView.NO_POSITION) {
@@ -24,7 +25,7 @@ public class ViewHolder extends RecyclerView.ViewHolder {
 
     private View.OnLongClickListener onLongClickListener = new View.OnLongClickListener() {
         @Override
-        public boolean onLongClick(View v) {
+        public boolean onLongClick(@NonNull View v) {
             // Discard long click if the viewholder has been removed, but was still in the process of
             // animating its removal while long clicked (unlikely, but technically possible)
             if (onItemLongClickListener != null && getAdapterPosition() != RecyclerView.NO_POSITION) {
@@ -34,12 +35,11 @@ public class ViewHolder extends RecyclerView.ViewHolder {
         }
     };
 
-    public ViewHolder(View rootView) {
+    public ViewHolder(@NonNull View rootView) {
         super(rootView);
-        this.rootView = rootView;
     }
 
-    public void bind(Item item, OnItemClickListener onItemClickListener, OnItemLongClickListener onItemLongClickListener) {
+    public void bind(@NonNull Item item, @Nullable OnItemClickListener onItemClickListener, @Nullable OnItemLongClickListener onItemLongClickListener) {
         this.item = item;
 
         // Only set the top-level click listeners if a) they exist, and b) the item has
@@ -49,12 +49,12 @@ public class ViewHolder extends RecyclerView.ViewHolder {
         // the viewholder, but different items of the same layout type may not have the same click
         // listeners or even agree on whether they are clickable.
         if (onItemClickListener != null && item.isClickable()) {
-            rootView.setOnClickListener(onClickListener);
+            itemView.setOnClickListener(onClickListener);
             this.onItemClickListener = onItemClickListener;
         }
 
         if (onItemLongClickListener != null && item.isLongClickable()) {
-            rootView.setOnLongClickListener(onLongClickListener);
+            itemView.setOnLongClickListener(onLongClickListener);
             this.onItemLongClickListener = onItemLongClickListener;
         }
     }
@@ -65,17 +65,17 @@ public class ViewHolder extends RecyclerView.ViewHolder {
         // This avoids undoing any click listeners the user may set which might be persistent for
         // the life of the viewholder. (It's up to the user to make sure that's correct behavior.)
         if (onItemClickListener != null && item.isClickable()) {
-            rootView.setOnClickListener(null);
+            itemView.setOnClickListener(null);
         }
         if (onItemLongClickListener != null && item.isLongClickable()) {
-            rootView.setOnLongClickListener(null);
+            itemView.setOnLongClickListener(null);
         }
         this.item = null;
         this.onItemClickListener = null;
         this.onItemLongClickListener = null;
     }
 
-    public Map<String, Object> getExtras() {
+    public @NonNull Map<String, Object> getExtras() {
         return item.getExtras();
     }
 
@@ -92,6 +92,6 @@ public class ViewHolder extends RecyclerView.ViewHolder {
     }
 
     public View getRoot() {
-        return rootView;
+        return itemView;
     }
 }

--- a/library/src/test/java/com/xwray/groupie/DummyGroup.java
+++ b/library/src/test/java/com/xwray/groupie/DummyGroup.java
@@ -1,19 +1,27 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
+
 public abstract class DummyGroup implements Group {
 
+    @NonNull
     @Override
     public Item getItem(int position) {
         return null;
     }
 
     @Override
-    public int getPosition(Item item) {
+    public int getPosition(@NonNull Item item) {
         return 0;
     }
 
     @Override
-    public void setGroupDataObserver(GroupDataObserver groupDataObserver) {
+    public void registerGroupDataObserver(@NonNull GroupDataObserver groupDataObserver) {
+
+    }
+
+    @Override
+    public void unregisterGroupDataObserver(@NonNull GroupDataObserver groupDataObserver) {
 
     }
 }

--- a/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
+++ b/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
@@ -1,5 +1,7 @@
 package com.xwray.groupie;
 
+import android.support.annotation.NonNull;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -17,7 +19,7 @@ public class ExpandableGroupTest {
 
     class DummyExpandableItem extends DummyItem implements ExpandableItem {
 
-        @Override public void setExpandableGroup(ExpandableGroup onToggleListener) {
+        @Override public void setExpandableGroup(@NonNull ExpandableGroup onToggleListener) {
 
         }
     }
@@ -32,7 +34,7 @@ public class ExpandableGroupTest {
     @Test
     public void noAddNotificationWhenCollapsed() throws Exception {
         ExpandableGroup expandableGroup = new ExpandableGroup(parent);
-        expandableGroup.setGroupDataObserver(groupAdapter);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
         expandableGroup.add(new DummyItem());
         Mockito.verify(groupAdapter, Mockito.never()).onItemRangeInserted(expandableGroup, 1, 1);
     }
@@ -40,7 +42,7 @@ public class ExpandableGroupTest {
     @Test
     public void noChildAddNotificationWhenCollapsed() {
         ExpandableGroup expandableGroup = new ExpandableGroup(parent);
-        expandableGroup.setGroupDataObserver(groupAdapter);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
         Section section = new Section();
         DummyItem item = new DummyItem();
         expandableGroup.add(section);
@@ -52,7 +54,7 @@ public class ExpandableGroupTest {
     public void addNotificationWhenExpanded() throws Exception {
         ExpandableGroup expandableGroup = new ExpandableGroup(parent);
         expandableGroup.onToggleExpanded();
-        expandableGroup.setGroupDataObserver(groupAdapter);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
         expandableGroup.add(new DummyItem());
         Mockito.verify(groupAdapter).onItemRangeInserted(expandableGroup, 1, 1);
     }
@@ -61,7 +63,7 @@ public class ExpandableGroupTest {
     public void childAddNotificationWhenExpanded() {
         ExpandableGroup expandableGroup = new ExpandableGroup(parent);
         expandableGroup.onToggleExpanded();
-        expandableGroup.setGroupDataObserver(groupAdapter);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
         Section section = new Section();
         DummyItem item = new DummyItem();
         expandableGroup.add(section);
@@ -117,7 +119,7 @@ public class ExpandableGroupTest {
         expandableGroup.add(section);
         Item lastItem = new DummyItem();
         expandableGroup.add(lastItem);
-        expandableGroup.setGroupDataObserver(groupAdapter);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
         expandableGroup.onToggleExpanded();
 
         Mockito.verify(groupAdapter).onItemRangeInserted(expandableGroup, 1, 6);
@@ -135,7 +137,7 @@ public class ExpandableGroupTest {
         Item lastItem = new DummyItem();
         expandableGroup.add(lastItem);
         expandableGroup.onToggleExpanded();
-        expandableGroup.setGroupDataObserver(groupAdapter);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
         expandableGroup.onToggleExpanded();
 
         Mockito.verify(groupAdapter).onItemRangeRemoved(expandableGroup, 1, 6);
@@ -152,7 +154,7 @@ public class ExpandableGroupTest {
         expandableGroup.add(section);
         Item lastItem = new DummyItem();
         expandableGroup.add(lastItem);
-        expandableGroup.setGroupDataObserver(groupAdapter);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
         expandableGroup.onToggleExpanded();
 
         assertEquals(3, expandableGroup.getGroupCount());

--- a/library/src/test/java/com/xwray/groupie/ItemTest.java
+++ b/library/src/test/java/com/xwray/groupie/ItemTest.java
@@ -31,7 +31,7 @@ public class ItemTest {
     @Test
     public void notifyChangeNotifiesParentObserver() {
         Item item = new DummyItem();
-        item.setGroupDataObserver(groupAdapter);
+        item.registerGroupDataObserver(groupAdapter);
         item.notifyChanged();
 
         verify(groupAdapter).onItemChanged(item, 0);

--- a/library/src/test/java/com/xwray/groupie/SectionTest.java
+++ b/library/src/test/java/com/xwray/groupie/SectionTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.never;
@@ -64,7 +63,7 @@ public class SectionTest {
         Section section = new Section();
         section.setHeader(header);
         section.add(new DummyItem());
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setFooter(footer);
 
         verify(groupAdapter).onItemRangeInserted(section, headerSize + 1, footerSize);
@@ -76,7 +75,7 @@ public class SectionTest {
         section.setHeader(header);
         section.add(new DummyItem());
         section.setFooter(footer);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.removeFooter();
 
         verify(groupAdapter).onItemRangeRemoved(section, headerSize + 1, footerSize);
@@ -107,7 +106,7 @@ public class SectionTest {
     @Test
     public void settingHeaderNotifiesHeaderAdded() {
         Section section = new Section();
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setHeader(header);
 
         verify(groupAdapter).onItemRangeInserted(section, 0, headerSize);
@@ -116,7 +115,7 @@ public class SectionTest {
     @Test
     public void removingHeaderNotifiesPreviousHeaderRemoved() {
         Section section = new Section();
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setHeader(header);
         section.removeHeader();
 
@@ -167,7 +166,7 @@ public class SectionTest {
         children.add(item);
         Section section = new Section(null, children);
 
-        verify(item).setGroupDataObserver(section);
+        verify(item).registerGroupDataObserver(section);
     }
 
     @Test
@@ -175,7 +174,7 @@ public class SectionTest {
         Section section = new Section();
         section.setHeader(header);
         section.setFooter(footer);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setPlaceholder(placeholder);
 
         verify(groupAdapter).onItemRangeInserted(section, headerSize, placeholderSize);
@@ -197,7 +196,7 @@ public class SectionTest {
         section.setHeader(header);
         section.setFooter(footer);
         section.add(new DummyItem());
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setPlaceholder(placeholder);
 
         verify(groupAdapter, never()).onItemRangeInserted(any(Section.class), anyInt(), anyInt());
@@ -227,7 +226,7 @@ public class SectionTest {
     @Test
     public void addEmptyBodyContentDoesNotRemovePlaceholder() {
         Section section = new Section();
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setPlaceholder(placeholder);
         section.add(emptyGroup);
 
@@ -237,7 +236,7 @@ public class SectionTest {
     @Test
     public void addBodyContentRemovesPlaceholder() {
         Section section = new Section();
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setPlaceholder(placeholder);
         section.add(new DummyItem());
 
@@ -250,7 +249,7 @@ public class SectionTest {
         section.setPlaceholder(placeholder);
         Item item = new DummyItem();
         section.add(item);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.remove(item);
 
         verify(groupAdapter).onItemRangeInserted(section, 0, placeholderSize);
@@ -264,7 +263,7 @@ public class SectionTest {
         Item childItem = new DummyItem();
         childGroup.add(childItem);
         section.add(childGroup);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         childGroup.remove(childItem);
 
         verify(groupAdapter).onItemRangeInserted(section, 0, placeholderSize);
@@ -276,7 +275,7 @@ public class SectionTest {
         section.setHeader(header);
         section.setFooter(footer);
         section.setPlaceholder(placeholder);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.removePlaceholder();
 
         verify(groupAdapter).onItemRangeRemoved(section, headerSize, placeholderSize);
@@ -286,7 +285,7 @@ public class SectionTest {
     public void setHideWhenEmptyRemovesAnExistingPlaceholder() {
         Section section = new Section();
         section.setPlaceholder(placeholder);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setHideWhenEmpty(true);
 
         verify(groupAdapter).onItemRangeRemoved(section, 0, placeholderSize);
@@ -296,7 +295,7 @@ public class SectionTest {
     public void replacingAnExistingPlaceholderNotifiesChange() {
         Section section = new Section();
         section.setPlaceholder(placeholder);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
 
         final int newPlaceholderSize = 1;
         Group newPlaceholder = new DummyGroup() {
@@ -314,7 +313,7 @@ public class SectionTest {
     @Test
     public void setHeaderAddsHeader() {
         Section section = new Section();
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setHeader(header);
 
         verify(groupAdapter).onItemRangeInserted(section, 0, headerSize);
@@ -324,7 +323,7 @@ public class SectionTest {
     public void removeHeaderRemovesHeader() {
         Section section = new Section();
         section.setHeader(header);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.removeHeader();
 
         verify(groupAdapter).onItemRangeRemoved(section, 0, headerSize);
@@ -333,7 +332,7 @@ public class SectionTest {
     @Test
     public void setFooterAddsFooter() {
         Section section = new Section();
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setFooter(footer);
 
         verify(groupAdapter).onItemRangeInserted(section, 0, footerSize);
@@ -343,7 +342,7 @@ public class SectionTest {
     public void removeFooterRemovesFooter() {
         Section section = new Section();
         section.setFooter(footer);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.removeFooter();
 
         verify(groupAdapter).onItemRangeRemoved(section, 0, footerSize);
@@ -354,7 +353,7 @@ public class SectionTest {
         Section section = new Section();
         section.setHeader(header);
         section.setFooter(footer);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setHideWhenEmpty(true);
 
         verify(groupAdapter).onItemRangeRemoved(section, 0, headerSize + footerSize);
@@ -366,7 +365,7 @@ public class SectionTest {
         section.setHeader(header);
         section.setFooter(footer);
         section.setPlaceholder(placeholder);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setHideWhenEmpty(true);
 
         verify(groupAdapter).onItemRangeRemoved(section, 0, headerSize + footerSize + placeholderSize);
@@ -378,7 +377,7 @@ public class SectionTest {
         section.setHeader(header);
         section.setFooter(footer);
         section.setHideWhenEmpty(true);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.setHideWhenEmpty(false);
 
         verify(groupAdapter).onItemRangeInserted(section, 0, headerSize);
@@ -429,28 +428,27 @@ public class SectionTest {
         assertEquals(0, section.getGroupCount());
     }
 
-    @Test
-    public void whenSectionIsEmptyAndSetHideWhenEmptyGetGroupReturnsNull() {
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void whenSectionIsEmptyAndSetHideWhenEmptyGetGroupThrowsException() {
         Section section = new Section();
         section.setHeader(header);
         section.setPlaceholder(placeholder);
         section.setFooter(footer);
         section.setHideWhenEmpty(true);
-
-        assertNull(section.getGroup(0));
+        section.getGroup(0);
     }
 
     @Test(expected = IndexOutOfBoundsException.class)
     public void addAllAtNonZeroPositionWhenEmptyThrowIndexOutOfBoundsException() {
         final Section section = new Section();
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
         section.addAll(1, Arrays.asList(new DummyItem(), new DummyItem()));
     }
 
     @Test
     public void addAllAtPositionWhenEmptyNotifiesAdapterAtIndexZero() {
         final Section section = new Section();
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
 
         section.addAll(0, Arrays.asList(new DummyItem(), new DummyItem()));
         verify(groupAdapter).onItemRangeInserted(section, 0, 2);
@@ -459,7 +457,7 @@ public class SectionTest {
     @Test
     public void addAllAtPositionWhenNonEmptyNotifiesAdapterAtCorrectIndex() {
         final Section section = new Section(Arrays.asList(new DummyItem(), new DummyItem()));
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
 
         section.addAll(2, Arrays.asList(new DummyItem(), new DummyItem(), new DummyItem()));
         verify(groupAdapter).onItemRangeInserted(section, 2, 3);
@@ -471,7 +469,7 @@ public class SectionTest {
 
         final Section section = new Section();
         section.add(nestedSection);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
 
         section.addAll(1, Arrays.asList(new DummyItem(), new DummyItem(), new DummyItem()));
         verify(groupAdapter).onItemRangeInserted(section, 0, 3);
@@ -484,7 +482,7 @@ public class SectionTest {
 
         final Section section = new Section();
         section.add(nestedSection);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
 
         section.addAll(0, Arrays.asList(new DummyItem(), new DummyItem(), new DummyItem()));
         verify(groupAdapter).onItemRangeInserted(section, 0, 3);
@@ -496,7 +494,7 @@ public class SectionTest {
         final Section nestedSection2 = new Section(Arrays.asList(new DummyItem(), new DummyItem()));
 
         final Section section = new Section(Arrays.asList(nestedSection1, nestedSection2));
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
 
         section.addAll(1, Arrays.asList(new DummyItem(), new DummyItem(), new DummyItem()));
         verify(groupAdapter).onItemRangeInserted(section, 2, 3);
@@ -509,7 +507,7 @@ public class SectionTest {
 
         final Section section = new Section();
         section.add(nestedSection);
-        section.setGroupDataObserver(groupAdapter);
+        section.registerGroupDataObserver(groupAdapter);
 
         section.addAll(1, Arrays.asList(new DummyItem(), new DummyItem()));
         verify(groupAdapter).onItemRangeInserted(section, 2, 2);
@@ -519,7 +517,7 @@ public class SectionTest {
     public void addItemToNestedSectionNotifiesAtCorrectIndex() throws Exception {
         final Section rootSection = new Section();
 
-        rootSection.setGroupDataObserver(groupAdapter);
+        rootSection.registerGroupDataObserver(groupAdapter);
         groupAdapter.add(rootSection);
 
         final Section nestedSection1 = new Section(Arrays.asList(new DummyItem(), new DummyItem(), new DummyItem()));
@@ -537,7 +535,7 @@ public class SectionTest {
     public void addGroupToNestedSectionNotifiesAtCorrectIndex() throws Exception {
         final Section rootSection = new Section();
 
-        rootSection.setGroupDataObserver(groupAdapter);
+        rootSection.registerGroupDataObserver(groupAdapter);
         groupAdapter.add(rootSection);
 
         final Section nestedSection1 = new Section(Arrays.asList(new DummyItem(), new DummyItem(), new DummyItem()));
@@ -555,7 +553,7 @@ public class SectionTest {
         final Section rootSection = new Section();
         rootSection.setHeader(new DummyItem());
 
-        rootSection.setGroupDataObserver(groupAdapter);
+        rootSection.registerGroupDataObserver(groupAdapter);
         groupAdapter.add(rootSection);
 
         final Section nestedSection1 = new Section(Arrays.asList(new DummyItem(), new DummyItem(), new DummyItem()));
@@ -572,7 +570,7 @@ public class SectionTest {
     public void insertGroupToNestedSectionNotifiesAtCorrectIndex() throws Exception {
         final Section rootSection = new Section();
 
-        rootSection.setGroupDataObserver(groupAdapter);
+        rootSection.registerGroupDataObserver(groupAdapter);
         groupAdapter.add(rootSection);
 
         final Section nestedSection1 = new Section(Arrays.asList(new DummyItem(), new DummyItem()));
@@ -603,7 +601,7 @@ public class SectionTest {
     public void removeGroupFromNestedSectionNotifiesAtCorrectIndex() throws Exception {
         final Section rootSection = new Section();
 
-        rootSection.setGroupDataObserver(groupAdapter);
+        rootSection.registerGroupDataObserver(groupAdapter);
         groupAdapter.add(rootSection);
 
         final Section nestedSection1 = new Section(Arrays.asList(new DummyItem(), new DummyItem(), new DummyItem()));

--- a/library/src/test/java/com/xwray/groupie/UpdatingGroupTest.java
+++ b/library/src/test/java/com/xwray/groupie/UpdatingGroupTest.java
@@ -49,7 +49,7 @@ public class UpdatingGroupTest {
         children.add(new AlwaysUpdatingItem(2));
 
         UpdatingGroup group = new UpdatingGroup();
-        group.setGroupDataObserver(groupAdapter);
+        group.registerGroupDataObserver(groupAdapter);
 
         group.update(children);
         verify(groupAdapter).onItemRangeInserted(group, 0, 2);
@@ -68,7 +68,7 @@ public class UpdatingGroupTest {
 
         UpdatingGroup group = new UpdatingGroup();
         group.update(children);
-        group.setGroupDataObserver(groupAdapter);
+        group.registerGroupDataObserver(groupAdapter);
 
         item.notifyChanged();
 


### PR DESCRIPTION
In order to guarantee non-nullable on more methods, the behavior of some methods has changed.
In particular, a few methods like getItem() / getGroup() which used to return null if not
present now throw IndexOutOfBoundsException. You can still check if an Item is present by
checking for its index being > -1.
Additionally, setGroupDataObserver is now register/unregisterGroupDataObserver and its arguments are `@NonNull`.