### PR TITLE
Fixed addAll function of ExpandableGroup and allow to initial ExpandableGroup with isExpanded property

### DIFF
--- a/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
+++ b/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
@@ -3,6 +3,7 @@ package com.xwray.groupie;
 import android.support.annotation.NonNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -29,6 +30,34 @@ public class ExpandableGroup extends NestedGroup {
             notifyItemRangeInserted(itemCount, group.getItemCount());
         } else {
             children.add(group);
+        }
+    }
+
+    @Override
+    public void addAll(@NonNull Collection<? extends Group> groups) {
+        if (groups.isEmpty()) return;
+        super.addAll(groups);
+        if (isExpanded) {
+            int itemCount = getItemCount();
+            this.children.addAll(groups);
+            notifyItemRangeInserted(itemCount, getItemCount(groups));
+        } else {
+            this.children.addAll(groups);
+        }
+    }
+
+    @Override
+    public void addAll(int position, @NonNull Collection<? extends Group> groups) {
+        if (groups.isEmpty()) {
+            return;
+        }
+        super.addAll(position, groups);
+        if (isExpanded) {
+            int itemCount = getItemCount();
+            this.children.addAll(position, groups);
+            notifyItemRangeInserted(itemCount, getItemCount(groups));
+        } else {
+            this.children.addAll(position, groups);
         }
     }
 

--- a/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
+++ b/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
@@ -22,6 +22,12 @@ public class ExpandableGroup extends NestedGroup {
         ((ExpandableItem) expandableItem).setExpandableGroup(this);
     }
 
+    public ExpandableGroup(Group expandableItem, boolean isExpanded) {
+        this.parent = expandableItem;
+        ((ExpandableItem) expandableItem).setExpandableGroup(this);
+        this.isExpanded = isExpanded;
+    }
+
     @Override public void add(@NonNull Group group) {
         super.add(group);
         if (isExpanded) {

--- a/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
+++ b/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
@@ -8,6 +8,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 
@@ -158,5 +161,20 @@ public class ExpandableGroupTest {
         expandableGroup.onToggleExpanded();
 
         assertEquals(3, expandableGroup.getGroupCount());
+    }
+
+    @Test
+    public void testExpandedGroupCountForAddAll() throws Exception {
+        ExpandableGroup expandableGroup = new ExpandableGroup(parent);
+        List<DummyItem> items = new ArrayList<>();
+        int itemsCount = 5;
+        for (int i = 0; i < itemsCount; i++) {
+            items.add(new DummyItem());
+        }
+        expandableGroup.addAll(items);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
+        expandableGroup.onToggleExpanded();
+
+        assertEquals(6, expandableGroup.getGroupCount());
     }
 }

--- a/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
+++ b/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExpandableGroupTest {
@@ -32,6 +33,12 @@ public class ExpandableGroupTest {
     public void collapsedByDefault() throws Exception {
         ExpandableGroup expandableGroup = new ExpandableGroup(parent);
         assertFalse(expandableGroup.isExpanded());
+    }
+
+    @Test
+    public void expandedByDefault() throws Exception {
+        ExpandableGroup expandableGroup = new ExpandableGroup(parent, true);
+        assertTrue(expandableGroup.isExpanded());
     }
 
     @Test


### PR DESCRIPTION
This is actually meant for #108  and #109 

* Fixed the `addAll` function for `ExpandaleGroup`
* Allow to initial `ExpandableGroup` with `isExpanded` set, so that we might be able to initial an `ExpandableGroup` expanded by default