### PR TITLE
Section removeAll() notification fix

### DIFF
--- a/library/src/main/java/com/xwray/groupie/Section.java
+++ b/library/src/main/java/com/xwray/groupie/Section.java
@@ -100,9 +100,10 @@ public class Section extends NestedGroup {
         if (groups.isEmpty()) {
             return;
         }
+
         super.removeAll(groups);
         for (Group group : groups) {
-            int position = getPosition(group);
+            int position = getItemCountBeforeGroup(group);
             children.remove(group);
             notifyItemRangeRemoved(position, group.getItemCount());
         }


### PR DESCRIPTION
Section `removeAll()` was not notifying with the correct item positions.
1. Fix notification position
1. Added a few tests