### PR TITLE
Fix SettingsActivity

### DIFF
--- a/example-shared/src/main/java/com/xwray/groupie/example/core/SettingsActivity.java
+++ b/example-shared/src/main/java/com/xwray/groupie/example/core/SettingsActivity.java
@@ -20,8 +20,8 @@ public class SettingsActivity extends AppCompatActivity {
         TextView showBoundsText = (TextView) showBoundsContainer.findViewById(R.id.text);
 
         ViewGroup showOffsetsContainer = (ViewGroup) findViewById(R.id.show_offsets);
-        SwitchCompat showOffsetsSwitch =  (SwitchCompat) showBoundsContainer.findViewById(R.id.the_switch);
-        TextView showOffsetsText = (TextView) showBoundsContainer.findViewById(R.id.text);
+        SwitchCompat showOffsetsSwitch =  (SwitchCompat) showOffsetsContainer.findViewById(R.id.the_switch);
+        TextView showOffsetsText = (TextView) showOffsetsContainer.findViewById(R.id.text);
 
         showBoundsText.setText(R.string.show_bounds);
         showOffsetsText.setText(R.string.show_offsets);


### PR DESCRIPTION
`showBoundsContainer` was reused for offsets settings.

See before/after:

![before_after](https://user-images.githubusercontent.com/1921278/33379993-f58c1bf8-d519-11e7-9e9e-9388808f955d.png)