### PR TITLE
Fixes #118 full bleed item not being full bleed

### DIFF
--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/FullBleedCardItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/FullBleedCardItem.java
@@ -8,6 +8,6 @@ public class FullBleedCardItem extends CardItem {
 
     public FullBleedCardItem(@ColorRes int colorRes) {
         super(colorRes);
-        getExtras().put(MainActivity.INSET_TYPE_KEY, MainActivity.INSET);
+        getExtras().remove(MainActivity.INSET_TYPE_KEY);
     }
 }

--- a/example/src/main/java/com/xwray/groupie/example/item/FullBleedCardItem.kt
+++ b/example/src/main/java/com/xwray/groupie/example/item/FullBleedCardItem.kt
@@ -1,12 +1,11 @@
 package com.xwray.groupie.example.item
 
 import android.support.annotation.ColorRes
-import com.xwray.groupie.example.INSET
 import com.xwray.groupie.example.INSET_TYPE_KEY
 
 class FullBleedCardItem(@ColorRes colorRes: Int) : CardItem(colorRes) {
 
     init {
-        extras.put(INSET_TYPE_KEY, INSET)
+        extras.remove(INSET_TYPE_KEY)
     }
 }


### PR DESCRIPTION
FullBleedCardItem already inherits the CardItem inset.
Removing the extra parameter in init fixes the issue.