### PR TITLE
Closes #167

### DIFF
--- a/example-databinding/src/main/AndroidManifest.xml
+++ b/example-databinding/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
           xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".ExampleBindingApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/ExampleBindingApplication.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/ExampleBindingApplication.java
@@ -1,0 +1,11 @@
+package com.xwray.groupie.example.databinding;
+
+import android.app.Application;
+import android.support.v7.app.AppCompatDelegate;
+
+
+public class ExampleBindingApplication extends Application {
+    static {
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+    }
+}

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
           xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".ExampleApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"

--- a/example/src/main/java/com/xwray/groupie/example/ExampleApplication.java
+++ b/example/src/main/java/com/xwray/groupie/example/ExampleApplication.java
@@ -1,0 +1,11 @@
+package com.xwray.groupie.example;
+
+import android.app.Application;
+import android.support.v7.app.AppCompatDelegate;
+
+
+public class ExampleApplication extends Application {
+    static {
+        AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);
+    }
+}


### PR DESCRIPTION
Add `AppCompatDelegate.setCompatVectorFromResourcesEnabled(true);` in the extented Application class on Examples Application in order to full manage vecotor drawable for API level < 21:

https://developer.android.com/reference/android/support/v7/app/AppCompatDelegate.html#setCompatVectorFromResourcesEnabled(boolean)

This should closes issues #167 

Anyway there are still some other older (minTargetSdk = 14) API level compatibility.