### PR TITLE
Fix getAdapterPosition returning 0 when group not found

### DIFF
--- a/library/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -225,6 +225,7 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
      */
     public int getAdapterPosition(@NonNull Group group) {
         int index = groups.indexOf(group);
+        if (index == -1) return -1;
         int position = 0;
         for (int i = 0; i < index; i++) {
             position += groups.get(i).getItemCount();


### PR DESCRIPTION
This should fix Issue #176 