### PR TITLE
adding group and section plus/minus assign operators

### DIFF
--- a/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/GroupAdapterExt.kt
+++ b/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/GroupAdapterExt.kt
@@ -5,21 +5,17 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.Section
 import com.xwray.groupie.ViewHolder
 
-operator fun GroupAdapter<ViewHolder>.plusAssign(element: Group) {
-    this.add(element)
-}
+operator fun GroupAdapter<ViewHolder>.plusAssign(element: Group) = this.add(element)
 
-operator fun GroupAdapter<ViewHolder>.plusAssign(groups: MutableCollection<out Group>) {
-    this.addAll(groups)
-}
 
-operator fun GroupAdapter<ViewHolder>.minusAssign(element: Group) {
-    this.remove(element)
-}
+operator fun GroupAdapter<ViewHolder>.plusAssign(groups: MutableCollection<out Group>) = this.addAll(groups)
 
-operator fun GroupAdapter<ViewHolder>.minusAssign(groups: MutableCollection<out Group>) {
-    this.removeAll(groups)
-}
+
+operator fun GroupAdapter<ViewHolder>.minusAssign(element: Group) = this.remove(element)
+
+
+operator fun GroupAdapter<ViewHolder>.minusAssign(groups: MutableCollection<out Group>)  = this.removeAll(groups)
+
 
 fun Group() {
     val groupAdapter = GroupAdapter<ViewHolder>()

--- a/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/GroupAdapterExt.kt
+++ b/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/GroupAdapterExt.kt
@@ -1,0 +1,28 @@
+package com.xwray.groupie.groupiex
+
+import com.xwray.groupie.Group
+import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.Section
+import com.xwray.groupie.ViewHolder
+
+operator fun GroupAdapter<ViewHolder>.plusAssign(element: Group) {
+    this.add(element)
+}
+
+operator fun GroupAdapter<ViewHolder>.plusAssign(groups: MutableCollection<out Group>) {
+    this.addAll(groups)
+}
+
+operator fun GroupAdapter<ViewHolder>.minusAssign(element: Group) {
+    this.remove(element)
+}
+
+operator fun GroupAdapter<ViewHolder>.minusAssign(groups: MutableCollection<out Group>) {
+    this.removeAll(groups)
+}
+
+fun Group() {
+    val groupAdapter = GroupAdapter<ViewHolder>()
+    groupAdapter += Section()
+    groupAdapter += mutableListOf<Section>(Section(), Section())
+}

--- a/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/SectionExt.kt
+++ b/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/SectionExt.kt
@@ -1,0 +1,28 @@
+package com.xwray.groupie.groupiex
+
+import com.xwray.groupie.Group
+import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.Section
+import com.xwray.groupie.ViewHolder
+
+operator fun Section.plusAssign(element: Group) {
+    this.add(element)
+}
+
+operator fun Section.plusAssign(groups: MutableCollection<out Group>) {
+    this.addAll(groups)
+}
+
+operator fun Section.minusAssign(element: Group) {
+    this.remove(element)
+}
+
+operator fun Section.minusAssign(groups: MutableCollection<out Group>) {
+    this.removeAll(groups)
+}
+
+fun Section() {
+    val groupAdapter = GroupAdapter<ViewHolder>()
+    groupAdapter += Section()
+    groupAdapter += mutableListOf(Section(), Section())
+}

--- a/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/SectionExt.kt
+++ b/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/SectionExt.kt
@@ -5,21 +5,17 @@ import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.Section
 import com.xwray.groupie.ViewHolder
 
-operator fun Section.plusAssign(element: Group) {
-    this.add(element)
-}
+operator fun Section.plusAssign(element: Group)  = this.add(element)
 
-operator fun Section.plusAssign(groups: MutableCollection<out Group>) {
-    this.addAll(groups)
-}
 
-operator fun Section.minusAssign(element: Group) {
-    this.remove(element)
-}
+operator fun Section.plusAssign(groups: MutableCollection<out Group>) = this.addAll(groups)
 
-operator fun Section.minusAssign(groups: MutableCollection<out Group>) {
-    this.removeAll(groups)
-}
+
+operator fun Section.minusAssign(element: Group) = this.remove(element)
+
+
+operator fun Section.minusAssign(groups: MutableCollection<out Group>) = this.removeAll(groups)
+
 
 fun Section() {
     val groupAdapter = GroupAdapter<ViewHolder>()


### PR DESCRIPTION
closes #184 by adding plus assign and minus assign operators to Group & Section.  I did not write tests as as I am delegating to the previous impl (let me know if you'd like me to still wrap in tests for coverage).  I left an example in the source for each, I'll move these to readme if API/package structure is reasonable:

```
fun Section() {
    val groupAdapter = GroupAdapter<ViewHolder>()
    groupAdapter += Section()
    groupAdapter += mutableListOf(Section(), Section())
}

fun Group() {
    val groupAdapter = GroupAdapter<ViewHolder>()
    groupAdapter += Section()
    groupAdapter += mutableListOf<Section>(Section(), Section())
}
```

