### PR TITLE
 Fix a bug that ExpandableGroup#getPosition returns wrong index

### DIFF
--- a/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
+++ b/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
@@ -117,9 +117,12 @@ public class ExpandableGroup extends NestedGroup {
     public int getPosition(@NonNull Group group) {
         if (group == parent) {
             return 0;
-        } else {
-            return 1 + children.indexOf(group);
         }
+        int index = children.indexOf(group);
+        if (index >= 0) {
+            return index + 1;
+        }
+        return -1;
     }
 
     public int getGroupCount() {

--- a/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
+++ b/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
@@ -14,8 +14,6 @@ import java.util.List;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExpandableGroupTest {
@@ -105,6 +103,17 @@ public class ExpandableGroupTest {
     public void testGetHeaderPosition() throws Exception {
         ExpandableGroup expandableGroup = new ExpandableGroup(parent);
         assertEquals(0, expandableGroup.getPosition(parent));
+    }
+
+    @Test
+    public void testGetPosition() throws Exception {
+        ExpandableGroup expandableGroup = new ExpandableGroup(parent);
+        Section section = new Section();
+        expandableGroup.add(section);
+        Section notAddedSection = new Section();
+
+        assertEquals(1, expandableGroup.getPosition(section));
+        assertEquals(-1, expandableGroup.getPosition(notAddedSection));
     }
 
     @Test


### PR DESCRIPTION
Currently, ExpandableGroup#getPosition returns the same value (`0`) for parent item and nonexistent item. 

```java
@Test
public void testGetHeaderPosition() throws Exception {
    ExpandableGroup expandableGroup = new ExpandableGroup(parent);
    assertEquals(0, expandableGroup.getPosition(parent)); // parent position
    Section notAddedSection = new Section();
    assertEquals(0, expandableGroup.getPosition(notAddedSection)); // nonexistent item position
}
```

But Section and UpdatingGroup seems to return `-1` when target group does not exist, so I want to make ExpandableGroup the same behavior. This makes it clear that `0` is a parent item and `-1` is a nonexistent item. 

Please try to consider this ;)