### PR TITLE
Add getViewType method to Item class

### DIFF
--- a/library/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -1,6 +1,5 @@
 package com.xwray.groupie;
 
-import androidx.annotation.LayoutRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.DiffUtil;
@@ -150,10 +149,10 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
 
     @Override
     @NonNull
-    public VH onCreateViewHolder(@NonNull ViewGroup parent, int layoutResId) {
+    public VH onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         LayoutInflater inflater = LayoutInflater.from(parent.getContext());
-        Item<VH> item = getItemForViewType(layoutResId);
-        View itemView = inflater.inflate(layoutResId, parent, false);
+        Item<VH> item = getItemForViewType(viewType);
+        View itemView = inflater.inflate(item.getLayout(), parent, false);
         return item.createViewHolder(itemView);
     }
 
@@ -185,7 +184,7 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
         lastItemForViewTypeLookup = getItem(position);
         if (lastItemForViewTypeLookup == null)
             throw new RuntimeException("Invalid position " + position);
-        return lastItemForViewTypeLookup.getLayout();
+        return lastItemForViewTypeLookup.getViewType();
     }
 
     @Override
@@ -429,9 +428,9 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
      * To be safe, we fallback to searching through all models for a view type match. This is slow and
      * shouldn't be needed, but is a guard against RecyclerView behavior changing.
      */
-    private Item<VH> getItemForViewType(@LayoutRes int layoutResId) {
+    private Item<VH> getItemForViewType(int viewType) {
         if (lastItemForViewTypeLookup != null
-                && lastItemForViewTypeLookup.getLayout() == layoutResId) {
+                && lastItemForViewTypeLookup.getViewType() == viewType) {
             // We expect this to be a hit 100% of the time
             return lastItemForViewTypeLookup;
         }
@@ -439,12 +438,12 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
         // To be extra safe in case RecyclerView implementation details change...
         for (int i = 0; i < getItemCount(); i++) {
             Item item = getItem(i);
-            if (item.getLayout() == layoutResId) {
+            if (item.getViewType() == viewType) {
                 return item;
             }
         }
 
-        throw new IllegalStateException("Could not find model for view type: " + layoutResId);
+        throw new IllegalStateException("Could not find model for view type: " + viewType);
     }
 
     private static class DiffCallback extends DiffUtil.Callback {

--- a/library/src/main/java/com/xwray/groupie/Item.java
+++ b/library/src/main/java/com/xwray/groupie/Item.java
@@ -100,6 +100,15 @@ public abstract class Item<VH extends ViewHolder> implements Group, SpanSizeProv
     @LayoutRes
     public abstract int getLayout();
 
+    /**
+     * Override this method if the same layout needs to have different viewTypes.
+     * @return the viewType, defaults to the layoutId
+     * @see RecyclerView.Adapter#getItemViewType(int)
+     */
+    public int getViewType() {
+        return getLayout();
+    }
+
     @Override
     public int getItemCount() {
         return 1;
@@ -181,7 +190,7 @@ public abstract class Item<VH extends ViewHolder> implements Group, SpanSizeProv
      * The default implementation compares both view type and id.
      */
     public boolean isSameAs(Item other) {
-        if (getLayout() != other.getLayout()) {
+        if (getViewType() != other.getViewType()) {
             return false;
         }
         return getId() == other.getId();

--- a/library/src/main/java/com/xwray/groupie/UpdatingGroup.java
+++ b/library/src/main/java/com/xwray/groupie/UpdatingGroup.java
@@ -98,7 +98,7 @@ public class UpdatingGroup extends NestedGroup {
         public boolean areItemsTheSame(int oldItemPosition, int newItemPosition) {
             Item oldItem = items.get(oldItemPosition);
             Item newItem = newList.get(newItemPosition);
-            if (oldItem.getLayout() != newItem.getLayout()) {
+            if (oldItem.getViewType() != newItem.getViewType()) {
                 return false;
             }
             return oldItem.getId() == newItem.getId();

--- a/library/src/test/java/com/xwray/groupie/ViewTypeTest.java
+++ b/library/src/test/java/com/xwray/groupie/ViewTypeTest.java
@@ -1,0 +1,66 @@
+package com.xwray.groupie;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+
+import androidx.annotation.NonNull;
+
+public class ViewTypeTest {
+
+    @Test
+    public void noViewTypeOverrideReturnsLayout() {
+        Item item = new ItemWithoutViewTypeOverride(42);
+        Assert.assertEquals(item.getViewType(), 42);
+    }
+
+    @Test
+    public void viewTypeOverrideReturnsViewType() {
+        Item item = new ItemWithViewTypeOverride(42, 20);
+        Assert.assertEquals(item.getViewType(), 20);
+    }
+
+    static class ItemWithoutViewTypeOverride extends Item<ViewHolder> {
+        private final int layout;
+
+        ItemWithoutViewTypeOverride(int layout) {
+            this.layout = layout;
+        }
+
+        @Override
+        public void bind(@NonNull ViewHolder viewHolder, int position) {
+
+        }
+
+        @Override
+        public int getLayout() {
+            return layout;
+        }
+    }
+
+    static class ItemWithViewTypeOverride extends Item<ViewHolder> {
+        private final int layout;
+        private final int viewType;
+
+        ItemWithViewTypeOverride(int layout, int viewType) {
+            this.layout = layout;
+            this.viewType = viewType;
+        }
+
+
+        @Override
+        public void bind(@NonNull ViewHolder viewHolder, int position) {
+
+        }
+
+        @Override
+        public int getViewType() {
+            return viewType;
+        }
+
+        @Override
+        public int getLayout() {
+            return layout;
+        }
+    }
+}


### PR DESCRIPTION
I ran into a problem where I need to do some manipulation to the item view based on runtime state. 
This effectively meant that I had multiple viewTypes based off the same layoutId.

This PR adds a method `Item.getViewtype()` which has a default implementation to return the `getLayout()`. `GroupAdapter` then uses that `getViewType()` method in all places where it used `getLayout()` before, with the exception of the actual place where the layout inflation happens.

After this PR it becomes possible to have different viewTypes from the same layout.