### PR TITLE
Add GroupAdapter.getGroupCount()

### DIFF
--- a/library/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -240,6 +240,13 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
         return position;
     }
 
+    /**
+     * Returns the number of top-level groups present in the adapter.
+     */
+    public int getGroupCount() {
+        return groups.size();
+    }
+
     private static int getItemCount(Collection<? extends Group> groups) {
         int count = 0;
         for (Group group : groups) {


### PR DESCRIPTION
This method would be useful for production testing to verify that a given GroupAdapter has the expected number of Groups present.

On another note, I helped implement an extremely similar library (Bento) during my time at Yelp (if only we had realized something like this already existed).

One interesting hack I discovered was that the `GroupAdapter` itself could be backed by a single top-level `Section` (or plain concrete `NestedGroup`) instead of another `List<Group>`. This allows the Adapter to emulate its current `NestedGroup`-like interfaces (`add(Group)`, `addAll`, `remove`, etc.) using logic already implemented in `NestedGroup` by simply acting as a wrapper.

Feel free to ask questions if you're interested!