### PR TITLE
Create a method to set expanded value to an `ExpandableGroup`

### DIFF
--- a/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
+++ b/library/src/main/java/com/xwray/groupie/ExpandableGroup.java
@@ -1,10 +1,10 @@
 package com.xwray.groupie;
 
-import androidx.annotation.NonNull;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import androidx.annotation.NonNull;
 
 /**
  * An ExpandableContentItem is one "base" content item with a list of children (any of which
@@ -137,6 +137,12 @@ public class ExpandableGroup extends NestedGroup {
             notifyItemRangeRemoved(newSize, oldSize - newSize);
         } else {
             notifyItemRangeInserted(oldSize, newSize - oldSize);
+        }
+    }
+
+    public void setExpanded(boolean isExpanded) {
+        if (this.isExpanded != isExpanded) {
+            onToggleExpanded();
         }
     }
 

--- a/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
+++ b/library/src/test/java/com/xwray/groupie/ExpandableGroupTest.java
@@ -1,7 +1,5 @@
 package com.xwray.groupie;
 
-import androidx.annotation.NonNull;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -10,6 +8,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import androidx.annotation.NonNull;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -164,6 +164,78 @@ public class ExpandableGroupTest {
         expandableGroup.onToggleExpanded();
 
         Mockito.verify(groupAdapter).onItemRangeRemoved(expandableGroup, 1, 6);
+    }
+    
+    @Test
+    public void setExpandedShouldntNotifiesExpandWhenTheValueNotChanged() throws Exception {
+        ExpandableGroup expandableGroup = new ExpandableGroup(parent, true);
+        Section section = new Section();
+        int sectionSize = 5;
+        for (int i = 0; i < sectionSize; i++) {
+            section.add(new DummyItem());
+        }
+        expandableGroup.add(section);
+        Item lastItem = new DummyItem();
+        expandableGroup.add(lastItem);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
+        expandableGroup.setExpanded(true);
+
+        Mockito.verifyNoMoreInteractions(groupAdapter);
+        assertTrue(expandableGroup.isExpanded());
+    }
+
+    @Test
+    public void setExpandedShouldntNotifiesCollapseWhenTheValueNotChanged() throws Exception {
+        ExpandableGroup expandableGroup = new ExpandableGroup(parent, false);
+        Section section = new Section();
+        int sectionSize = 5;
+        for (int i = 0; i < sectionSize; i++) {
+            section.add(new DummyItem());
+        }
+        expandableGroup.add(section);
+        Item lastItem = new DummyItem();
+        expandableGroup.add(lastItem);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
+        expandableGroup.setExpanded(false);
+
+        Mockito.verifyNoMoreInteractions(groupAdapter);
+        assertFalse(expandableGroup.isExpanded());
+    }
+
+    @Test
+    public void setExpandedShouldNotifiesExpandWhenTheValueChanged() throws Exception {
+        ExpandableGroup expandableGroup = new ExpandableGroup(parent, false);
+        Section section = new Section();
+        int sectionSize = 5;
+        for (int i = 0; i < sectionSize; i++) {
+            section.add(new DummyItem());
+        }
+        expandableGroup.add(section);
+        Item lastItem = new DummyItem();
+        expandableGroup.add(lastItem);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
+        expandableGroup.setExpanded(true);
+
+        Mockito.verify(groupAdapter).onItemRangeInserted(expandableGroup, 1, 6);
+        assertTrue(expandableGroup.isExpanded());
+    }
+
+    @Test
+    public void setExpandedShouldNotifiesCollapseWhenTheValueChanged() throws Exception {
+        ExpandableGroup expandableGroup = new ExpandableGroup(parent, true);
+        Section section = new Section();
+        int sectionSize = 5;
+        for (int i = 0; i < sectionSize; i++) {
+            section.add(new DummyItem());
+        }
+        expandableGroup.add(section);
+        Item lastItem = new DummyItem();
+        expandableGroup.add(lastItem);
+        expandableGroup.registerGroupDataObserver(groupAdapter);
+        expandableGroup.setExpanded(false);
+
+        Mockito.verify(groupAdapter).onItemRangeRemoved(expandableGroup, 1, 6);
+        assertFalse(expandableGroup.isExpanded());
     }
 
     @Test


### PR DESCRIPTION
Create a method to set expanded value to an `ExpandableGroup`
It is a complementary method of `onToggleExpanded()` method to set an implicit value.
I haven't changed the `onToggleExpanded()` method visibility because it would be a breaking change in the public API of the library

This PR fix #108 issue