### PR TITLE
Allow specifying false for DiffUtil detect moves

### DIFF
--- a/library/src/main/java/com/xwray/groupie/AsyncDiffUtil.java
+++ b/library/src/main/java/com/xwray/groupie/AsyncDiffUtil.java
@@ -42,10 +42,13 @@ class AsyncDiffUtil {
         return maxScheduledGeneration;
     }
 
-    void calculateDiff(@NonNull Collection<? extends Group> newGroups, @NonNull DiffUtil.Callback diffUtilCallback, @Nullable OnAsyncUpdateListener onAsyncUpdateListener) {
+    void calculateDiff(@NonNull Collection<? extends Group> newGroups,
+                       @NonNull DiffUtil.Callback diffUtilCallback,
+                       @Nullable OnAsyncUpdateListener onAsyncUpdateListener,
+                       boolean detectMoves) {
         groups = newGroups;
         // incrementing generation means any currently-running diffs are discarded when they finish
         final int runGeneration = ++maxScheduledGeneration;
-        new DiffTask(this, diffUtilCallback, runGeneration, onAsyncUpdateListener).execute();
+        new DiffTask(this, diffUtilCallback, runGeneration, detectMoves, onAsyncUpdateListener).execute();
     }
 }

--- a/library/src/main/java/com/xwray/groupie/DiffTask.java
+++ b/library/src/main/java/com/xwray/groupie/DiffTask.java
@@ -19,16 +19,19 @@ class DiffTask extends AsyncTask<Void, Void, DiffUtil.DiffResult> {
     @NonNull private final DiffUtil.Callback diffCallback;
     private final WeakReference<AsyncDiffUtil> asyncListDiffer;
     private final int runGeneration;
+    private final boolean detectMoves;
     @Nullable private WeakReference<OnAsyncUpdateListener> onAsyncUpdateListener;
     private Exception backgroundException = null;
 
     DiffTask(@NonNull AsyncDiffUtil asyncDiffUtil,
              @NonNull DiffUtil.Callback callback,
              int runGeneration,
+             boolean detectMoves,
              @Nullable OnAsyncUpdateListener onAsyncUpdateListener) {
         this.diffCallback = callback;
         this.asyncListDiffer = new WeakReference<>(asyncDiffUtil);
         this.runGeneration = runGeneration;
+        this.detectMoves = detectMoves;
         if (onAsyncUpdateListener != null) {
             this.onAsyncUpdateListener = new WeakReference<>(onAsyncUpdateListener);
         }
@@ -38,7 +41,7 @@ class DiffTask extends AsyncTask<Void, Void, DiffUtil.DiffResult> {
     @Nullable
     protected DiffUtil.DiffResult doInBackground(Void... voids) {
         try {
-            return DiffUtil.calculateDiff(diffCallback);
+            return DiffUtil.calculateDiff(diffCallback, detectMoves);
         } catch (Exception e) {
             backgroundException = e;
             return null;

--- a/library/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -93,7 +93,7 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
      */
     @SuppressWarnings("unused")
     public void updateAsync(@NonNull final List<? extends Group> newGroups) {
-        this.updateAsync(newGroups, null);
+        this.updateAsync(newGroups, true, null);
     }
 
     /**
@@ -106,15 +106,17 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
      *
      * @param newGroups List of {@link Group}
      * @param onAsyncUpdateListener Optional callback for when the async update is complete
+     * @param detectMoves Boolean is passed to {@link DiffUtil#calculateDiff(DiffUtil.Callback, boolean)}. Set to true
+     *                    if you want DiffUtil to detect moved items.
      */
     @SuppressWarnings("unused")
-    public void updateAsync(@NonNull final List<? extends Group> newGroups, @Nullable final OnAsyncUpdateListener onAsyncUpdateListener) {
+    public void updateAsync(@NonNull final List<? extends Group> newGroups, boolean detectMoves, @Nullable final OnAsyncUpdateListener onAsyncUpdateListener) {
         final List<Group> oldGroups = new ArrayList<>(groups);
         final int oldBodyItemCount = getItemCount(oldGroups);
         final int newBodyItemCount = getItemCount(newGroups);
 
         final DiffCallback diffUtilCallback = new DiffCallback(oldBodyItemCount, newBodyItemCount, oldGroups, newGroups);
-        asyncDiffUtil.calculateDiff(newGroups, diffUtilCallback, onAsyncUpdateListener);
+        asyncDiffUtil.calculateDiff(newGroups, diffUtilCallback, onAsyncUpdateListener, detectMoves);
     }
 
     /**

--- a/library/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -124,12 +124,26 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
      */
     @SuppressWarnings("unused")
     public void update(@NonNull final Collection<? extends Group> newGroups) {
+        update(newGroups, true);
+    }
+
+    /**
+     * Updates the adapter with a new list that will be diffed on the <em>main</em> thread
+     * and displayed once diff results are calculated. Not recommended for huge lists.
+     * @param newGroups List of {@link Group}
+     * @param detectMoves is passed to {@link DiffUtil#calculateDiff(DiffUtil.Callback, boolean)}. Set to true
+     *                    if you don't want DiffUtil to detect moved items.
+     */
+    @SuppressWarnings("unused")
+    public void update(@NonNull final Collection<? extends Group> newGroups, boolean detectMoves) {
         final List<Group> oldGroups = new ArrayList<>(groups);
         final int oldBodyItemCount = getItemCount(oldGroups);
         final int newBodyItemCount = getItemCount(newGroups);
 
         final DiffUtil.DiffResult diffResult = DiffUtil.calculateDiff(
-                new DiffCallback(oldBodyItemCount, newBodyItemCount, oldGroups, newGroups));
+                new DiffCallback(oldBodyItemCount, newBodyItemCount, oldGroups, newGroups),
+                detectMoves
+        );
 
         setNewGroups(newGroups);
 

--- a/library/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -89,6 +89,8 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
      * If you want to receive a callback once the update is complete call the
      * {@link #updateAsync(List, OnAsyncUpdateListener)} version
      *
+     * This will default detectMoves to true.
+     *
      * @param newGroups List of {@link Group}
      */
     @SuppressWarnings("unused")
@@ -122,6 +124,9 @@ public class GroupAdapter<VH extends ViewHolder> extends RecyclerView.Adapter<VH
     /**
      * Updates the adapter with a new list that will be diffed on the <em>main</em> thread
      * and displayed once diff results are calculated. Not recommended for huge lists.
+     *
+     * This will default detectMoves to true.
+     *
      * @param newGroups List of {@link Group}
      */
     @SuppressWarnings("unused")

--- a/library/src/main/java/com/xwray/groupie/Section.java
+++ b/library/src/main/java/com/xwray/groupie/Section.java
@@ -137,6 +137,8 @@ public class Section extends NestedGroup {
      * If you don't customize getId() or isSameAs() and equals(), the default implementations will return false,
      * meaning your Group will consider every update a complete change of everything.
      *
+     * This will default detectMoves to true.
+     *
      * @param newBodyGroups The new content of the section
      */
     public void update(@NonNull final Collection<? extends Group> newBodyGroups) {

--- a/library/src/main/java/com/xwray/groupie/Section.java
+++ b/library/src/main/java/com/xwray/groupie/Section.java
@@ -140,6 +140,25 @@ public class Section extends NestedGroup {
      * @param newBodyGroups The new content of the section
      */
     public void update(@NonNull final Collection<? extends Group> newBodyGroups) {
+        update(newBodyGroups, true);
+    }
+
+    /**
+     * Replace all existing body content and dispatch fine-grained change notifications to the
+     * parent using DiffUtil.
+     * <p>
+     * Item comparisons are made using:
+     * - Item.isSameAs(Item otherItem) (are items the same?)
+     * - Item.equals() (are contents the same?)
+     * <p>
+     * If you don't customize getId() or isSameAs() and equals(), the default implementations will return false,
+     * meaning your Group will consider every update a complete change of everything.
+     *
+     * @param newBodyGroups The new content of the section
+     * @param detectMoves is passed to {@link DiffUtil#calculateDiff(DiffUtil.Callback, boolean)}. Set to false if you
+     *                    don't want DiffUtil to detect moved items.
+     */
+    public void update(@NonNull final Collection<? extends Group> newBodyGroups, boolean detectMoves) {
 
         final List<Group> oldBodyGroups = new ArrayList<>(children);
         final int oldBodyItemCount = getItemCount(oldBodyGroups);
@@ -177,7 +196,7 @@ public class Section extends NestedGroup {
                 Item newItem = getItem(newBodyGroups, newItemPosition);
                 return oldItem.getChangePayload(newItem);
             }
-        });
+        }, detectMoves);
 
         super.removeAll(children);
         children.clear();


### PR DESCRIPTION
@ValCanBuild thanks so much for picking up the maintenance of the library!

This PR adds support for specifying that `detectMoves` parameter to diff util. 