### PR TITLE
library-databinding: remove duplicate dependency from build.gradle

### DIFF
--- a/library-databinding/build.gradle
+++ b/library-databinding/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     compileOnly("androidx.databinding:databinding-common:$databinding_version") {
         transitive = false
     }
-    compileOnly("androidx.recyclerview:recyclerview:1.0.0")
     compileOnly("androidx.annotation:annotation:1.0.0")
 }
 


### PR DESCRIPTION
`androidx.recyclerview:recyclerview:1.0.0` already specified at L33.