### PR TITLE
Pass view attach/detach events to the Item

### DIFF
--- a/library/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -466,6 +466,22 @@ public class GroupAdapter<VH extends GroupieViewHolder> extends RecyclerView.Ada
         notifyItemMoved(groupAdapterPosition + fromPosition, groupAdapterPosition + toPosition);
     }
 
+    @Override
+    public void onViewAttachedToWindow(@NonNull VH holder) {
+        super.onViewAttachedToWindow(holder);
+        Item item = getItem(holder);
+        //noinspection unchecked
+        item.onViewAttachedToWindow(holder);
+    }
+
+    @Override
+    public void onViewDetachedFromWindow(@NonNull VH holder) {
+        super.onViewDetachedFromWindow(holder);
+        Item item = getItem(holder);
+        //noinspection unchecked
+        item.onViewDetachedFromWindow(holder);
+    }
+
     /**
      * This idea was copied from Epoxy. :wave: Bright idea guys!
      * <p>

--- a/library/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -225,6 +225,22 @@ public class GroupAdapter<VH extends GroupieViewHolder> extends RecyclerView.Ada
     }
 
     @Override
+    public void onViewAttachedToWindow(@NonNull VH holder) {
+        super.onViewAttachedToWindow(holder);
+        Item item = getItem(holder);
+        //noinspection unchecked
+        item.onViewAttachedToWindow(holder);
+    }
+
+    @Override
+    public void onViewDetachedFromWindow(@NonNull VH holder) {
+        super.onViewDetachedFromWindow(holder);
+        Item item = getItem(holder);
+        //noinspection unchecked
+        item.onViewDetachedFromWindow(holder);
+    }
+
+    @Override
     public int getItemViewType(int position) {
         lastItemForViewTypeLookup = getItem(position);
         if (lastItemForViewTypeLookup == null)
@@ -464,22 +480,6 @@ public class GroupAdapter<VH extends GroupieViewHolder> extends RecyclerView.Ada
     public void onItemMoved(@NonNull Group group, int fromPosition, int toPosition) {
         int groupAdapterPosition = getAdapterPosition(group);
         notifyItemMoved(groupAdapterPosition + fromPosition, groupAdapterPosition + toPosition);
-    }
-
-    @Override
-    public void onViewAttachedToWindow(@NonNull VH holder) {
-        super.onViewAttachedToWindow(holder);
-        Item item = getItem(holder);
-        //noinspection unchecked
-        item.onViewAttachedToWindow(holder);
-    }
-
-    @Override
-    public void onViewDetachedFromWindow(@NonNull VH holder) {
-        super.onViewDetachedFromWindow(holder);
-        Item item = getItem(holder);
-        //noinspection unchecked
-        item.onViewDetachedFromWindow(holder);
     }
 
     /**

--- a/library/src/main/java/com/xwray/groupie/Item.java
+++ b/library/src/main/java/com/xwray/groupie/Item.java
@@ -100,6 +100,10 @@ public abstract class Item<VH extends GroupieViewHolder> implements Group, SpanS
     @LayoutRes
     public abstract int getLayout();
 
+    public void onViewAttachedToWindow(@NonNull VH viewHolder) {}
+
+    public void onViewDetachedFromWindow(@NonNull VH viewHolder) {}
+
     /**
      * Override this method if the same layout needs to have different viewTypes.
      * @return the viewType, defaults to the layoutId


### PR DESCRIPTION
I have an `Item` that requires to know if it's attached or not to the window to know when to start/stop animations and UI updates.

The simplest solution is to override the `RecyclerView::Adapter::onViewAttachedToWindow` (and the detach equivalent) method and pass it to the `Item`.

What are your thoughts on this? If this seems reasonable, it would be nice to have it in the library.