### PR TITLE
Add Example for How to Reorder Expandable Groups

### DIFF
--- a/example-shared/src/main/res/values/strings.xml
+++ b/example-shared/src/main/res/values/strings.xml
@@ -16,4 +16,7 @@
     <string name="show_offsets">Show offsets</string>
     <string name="update_with_payload">Update with payload</string>
     <string name="update_with_payload_subtitle">These items demonstrate robust, efficient partial asynchronous updates</string>
+    <string name="reorderable_section">Reorderable Section</string>
+    <string name="reorderable_item_title">Tap to Move</string>
+    <string name="reorderable_item_subtitle">Tapping on the title sends this group to the bottom of the section</string>
 </resources>

--- a/example/src/main/java/com/xwray/groupie/example/ExpandableHeaderItem.kt
+++ b/example/src/main/java/com/xwray/groupie/example/ExpandableHeaderItem.kt
@@ -13,6 +13,8 @@ class ExpandableHeaderItem(@StringRes titleStringResId: Int,
                            @StringRes subtitleResId: Int)
     : HeaderItem(titleStringResId, subtitleResId), ExpandableItem {
 
+    var clickListener: ((ExpandableHeaderItem) -> Unit)? = null
+
     private lateinit var expandableGroup: ExpandableGroup
 
     override fun bind(viewHolder: GroupieViewHolder, position: Int) {
@@ -26,6 +28,10 @@ class ExpandableHeaderItem(@StringRes titleStringResId: Int,
                 expandableGroup.onToggleExpanded()
                 bindIcon(viewHolder)
             }
+        }
+
+        viewHolder.itemView.setOnClickListener {
+            clickListener?.invoke(this)
         }
     }
 

--- a/example/src/main/java/com/xwray/groupie/example/MainActivity.kt
+++ b/example/src/main/java/com/xwray/groupie/example/MainActivity.kt
@@ -121,6 +121,27 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
+        // Reordering a Section of Expandable Groups
+        val section = Section(HeaderItem(R.string.reorderable_section))
+        val swappableExpandableGroup = mutableListOf<ExpandableGroup>()
+        for (i in 0..1) {
+            val header = ExpandableHeaderItem(R.string.reorderable_item_title, R.string.reorderable_item_subtitle)
+            val group = ExpandableGroup(header).apply {
+                for (j in 0..1) {
+                    add(CardItem(rainbow200[i*2 + j]))
+                }
+            }
+            header.clickListener = {
+                swappableExpandableGroup.remove(group)
+                swappableExpandableGroup.add(group)
+
+                section.update(swappableExpandableGroup)
+            }
+            swappableExpandableGroup.add(group)
+        }
+        section.addAll(swappableExpandableGroup)
+        groupAdapter += section
+
         // Columns
         groupAdapter += Section(HeaderItem(R.string.vertical_columns)).apply {
             add(makeColumnGroup())


### PR DESCRIPTION
I created issue #248 a while back and @ValCanBuild provided a suggestion for how to improve my code. I think this might be helpful for others who run into a similar use case.