### PR TITLE
BindableItem: add NonNull annotation to payloads argument of bind method

### DIFF
--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/HeartCardItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/HeartCardItem.java
@@ -70,7 +70,7 @@ public class HeartCardItem extends BindableItem<ItemHeartCardBinding> {
     }
 
     @Override
-    public void bind(@NonNull ItemHeartCardBinding binding, int position, List<Object> payloads) {
+    public void bind(@NonNull ItemHeartCardBinding binding, int position, @NonNull List<Object> payloads) {
         if (payloads.contains(FAVORITE)) {
             bindHeart(binding);
         } else {

--- a/library-databinding/src/main/java/com/xwray/groupie/databinding/BindableItem.java
+++ b/library-databinding/src/main/java/com/xwray/groupie/databinding/BindableItem.java
@@ -84,7 +84,7 @@ public abstract class BindableItem<T extends ViewDataBinding> extends Item<Group
      * @param position The adapter position
      * @param payloads A list of payloads (may be empty)
      */
-    public void bind(@NonNull T viewBinding, int position, List<Object> payloads) {
+    public void bind(@NonNull T viewBinding, int position, @NonNull List<Object> payloads) {
         bind(viewBinding, position);
     }
 }


### PR DESCRIPTION
payloads argument is NonNull because `RecyclerView.Adapter#onBindViewHolder` signature is 
`public void onBindViewHolder(@NonNull VH holder, int position, @NonNull List<Object> payloads)`
