### PR TITLE
Fixed groupie-viewbinding BindableItem.bind method's JavaDoc

### DIFF
--- a/library-viewbinding/src/main/java/com/xwray/groupie/viewbinding/BindableItem.java
+++ b/library-viewbinding/src/main/java/com/xwray/groupie/viewbinding/BindableItem.java
@@ -53,7 +53,7 @@ public abstract class BindableItem<T extends ViewBinding> extends Item<GroupieVi
     /**
      * Perform any actions required to set up the view for display.
      *
-     * @param viewBinding The ViewDataBinding to bind
+     * @param viewBinding The ViewBinding to bind
      * @param position The adapter position
      */
     public abstract void bind(@NonNull T viewBinding, int position);
@@ -64,7 +64,7 @@ public abstract class BindableItem<T extends ViewBinding> extends Item<GroupieVi
      * If you don't specify how to handle payloads in your implementation, they'll be ignored and
      * the adapter will do a full rebind.
      *
-     * @param viewBinding The ViewDataBinding to bind
+     * @param viewBinding The ViewBinding to bind
      * @param position The adapter position
      * @param payloads A list of payloads (may be empty)
      */


### PR DESCRIPTION
Fix javadoc of groupie-viewbinding's BindableItem.bind methods to refer to ViewBinding instead of ViewDataBinding.

Minuscule polishing related to #325:
I guess as a remainder of copying `groupie-databinding`'s `BindableItem`, `groupie-viewbinding`'s class still reference `ViewDataBinding` instead of `ViewBinding` in JavaDoc of `bind` methods.