### PR TITLE
Add automate library releases jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,27 +1,68 @@
-version: 2
-jobs:
-  build:
+version: 2.1
+
+executors:
+  defalut:
     working_directory: ~/code
     docker:
-      - image: circleci/android:api-28-alpha
+      - image: circleci/android:api-28
     environment:
-      JVM_OPTS: -Xmx3200m
+      JVM_OPTS: -Xmx1024m
+      GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError" -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false'
+
+commands:
+  cache_gradle:
+    parameters:
+      version:
+        type: string
+        default: v1
     steps:
-      - checkout
       - restore_cache:
-          key: jars-{{ checksum "build.gradle" }}
+          keys:
+            - gradle-cache-<< parameters.version >>-{{ checksum "build.gradle" }}
+            - gradle-cache-<< parameters.version >>-
       - run:
-          name: Run Lint
-          command: ./gradlew lint --console plain
-      - run:
-          name: Run Unit Tests
-          command: ./gradlew test --console plain
-      - store_artifacts:
-          path: build/lint-reports
-          destination: reports
-      - store_test_results:
-          path: library/build/test-results
+          name: Check android dependencies
+          command: ./gradlew androidDependencies
       - save_cache:
           paths:
             - ~/.gradle
-          key: jars-{{ checksum "build.gradle" }}
+          key: gradle-cache-<< parameters.version >>-{{ checksum "build.gradle" }}
+
+  run_lint:
+    steps:
+      - run:
+          name: Run lint
+          command: ./gradlew lint --console plain
+      - store_artifacts:
+          path: build/lint-reports
+          destination: reports
+
+  run_unit_test:
+    steps:
+      - run:
+          name: Run unit test
+          command: ./gradlew test --console plain
+      - store_test_results:
+          path: library/build/test-results
+
+jobs:
+  test_lint:
+    executor:
+      name: defalut
+    steps:
+      - checkout
+      - cache_gradle
+      - run_lint
+  test_unit_test:
+    executor:
+      name: defalut
+    steps:
+      - checkout
+      - cache_gradle
+      - run_unit_test
+
+workflows:
+  test:
+    jobs:
+      - test_lint
+      - test_unit_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,18 @@ commands:
       - store_test_results:
           path: library/build/test-results
 
+  create_local_properties:
+    steps:
+      - run:
+          name: Decode local.properties
+          command: echo $LOCAL_PROPERTIES_ENCODE | base64 -di | tee local.properties >/dev/null
+
+  run_upload_packages:
+    steps:
+      - run:
+          name: Upload packages
+          command: bintray_upload.sh
+
 jobs:
   test_lint:
     executor:
@@ -60,9 +72,25 @@ jobs:
       - checkout
       - cache_gradle
       - run_unit_test
+  upload_package:
+    executor:
+      name: defalut
+    steps:
+      - checkout
+      - cache_gradle
+      - create_local_properties
+      - run_upload_packages
 
 workflows:
   test:
     jobs:
       - test_lint
       - test_unit_test
+  upload_package:
+    jobs:
+      - upload_package:
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^\d+\.\d+\.\d+$/

--- a/bintray_upload.sh
+++ b/bintray_upload.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+./gradlew library:bintrayUpload
+./gradlew library-databinding:bintrayUpload
+./gradlew library-kotlin-android-extensions:bintrayUpload
+./gradlew library-viewbinding:bintrayUpload


### PR DESCRIPTION
ref #315

---

summary

- Update CircleCI v2.1 style
  - Improve gradle cache
- Add automate library release job
  - This job is kicked by git tag (Github release)

---

`create_local_properties` step creates `local.properties` from CircleCI's context.
So, please add the string generated in `base64 local.properties` as `LOCAL_PROPERTIES_ENCODE`.

This way is based on the following article.
[Android Continuous Integration using Fastlane and CircleCI 2.0 — Part III](https://medium.com/pink-room-club/android-continuous-integration-using-fastlane-and-circleci-2-0-part-iii-ccdf5b83d8f5)

It seemed that the required parameters were listed in the `local.properties`.
Please let me know if I missed anything. 😄 

---

I'm very sorry, but I can't do the operation test on CircleCI.
Therefore, I seek advice from the knowledgeable.

Thanks!