### PR TITLE
Making Kotlin extensions work with any class extending GroupieViewHolder

### DIFF
--- a/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/GroupAdapterExt.kt
+++ b/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/GroupAdapterExt.kt
@@ -4,14 +4,14 @@ import com.xwray.groupie.Group
 import com.xwray.groupie.GroupAdapter
 import com.xwray.groupie.GroupieViewHolder
 
-operator fun GroupAdapter<GroupieViewHolder>.plusAssign(element: Group) = this.add(element)
+operator fun GroupAdapter<out GroupieViewHolder>.plusAssign(element: Group) = this.add(element)
 
 
-operator fun GroupAdapter<GroupieViewHolder>.plusAssign(groups: Collection<Group>) = this.addAll(groups)
+operator fun GroupAdapter<out GroupieViewHolder>.plusAssign(groups: Collection<Group>) = this.addAll(groups)
 
 
-operator fun GroupAdapter<GroupieViewHolder>.minusAssign(element: Group) = this.remove(element)
+operator fun GroupAdapter<out GroupieViewHolder>.minusAssign(element: Group) = this.remove(element)
 
 
-operator fun GroupAdapter<GroupieViewHolder>.minusAssign(groups: Collection<Group>)  = this.removeAll(groups)
+operator fun GroupAdapter<out GroupieViewHolder>.minusAssign(groups: Collection<Group>)  = this.removeAll(groups)
 


### PR DESCRIPTION
Hello.

Just a simple PR to add extensions support for any class extending GroupieViewHolder. Especially, extensions now work with Kotlin's GroupieViewHolder, like so:

```kotlin
class MyItem : com.xwray.groupie.kotlinandroidextensions.Item() { ... }

val adapter = GroupAdapter<com.xwray.groupie.kotlinandroidextensions.GroupieViewHolder>()
adapter += MyItem()
```

Thanks!