### PR TITLE
Using a buildFeatures in the  README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ Add to your app module's `build.gradle`:
 
 ```gradle
 android {
-    viewBinding {
-        enabled = true
+    buildFeatures {
+        viewBinding true
     }
 }
 
@@ -264,8 +264,8 @@ Add to your app module's build.gradle:
 
 ```gradle
 android {
-    dataBinding {
-        enabled = true
+    buildFeatures {
+        dataBinding true
     }
 }
 


### PR DESCRIPTION
`android.viewBinding.enabled` and `android.dataBinding.enabled` is now obsoleted.
So I replace it with `android.buildFeatures.viewBinding` and `android.buildFeatures.dataBinding`.

FYI: https://developer.android.com/studio/releases/gradle-plugin#buildFeatures