### PR TITLE
Add GroupieAdapter to use GroupieViewHolder by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ Which one to choose?  It's up to you and what your project already uses. You can
     
 ## Get started
 
-Use a `GroupAdapter` anywhere you would normally use a `RecyclerView.Adapter`, and attach it to your RecyclerView as usual.
+Use a `GroupieAdapter` anywhere you would normally use a `RecyclerView.Adapter`, and attach it to your RecyclerView as usual.
 
 Kotlin
 ```kotlin
-val adapter = GroupAdapter()
+val adapter = GroupieAdapter()
 recyclerView.setAdapter(adapter)
 ```
 
 Java
 ```java
-GroupAdapter adapter = new GroupAdapter();
+GroupieAdapter adapter = new GroupieAdapter();
 recyclerView.setAdapter(adapter);
 ```
     
@@ -84,9 +84,9 @@ section.addAll(bodyItems);
 groupAdapter.add(section);
 ```
     
-Modifying the contents of the GroupAdapter in any way automatically sends change notifications.  Adding an item calls `notifyItemAdded()`; adding a group calls `notifyItemRangeAdded()`, etc.
+Modifying the contents of the GroupieAdapter in any way automatically sends change notifications.  Adding an item calls `notifyItemAdded()`; adding a group calls `notifyItemRangeAdded()`, etc.
 
-Modifying the contents of a Group automatically notifies its parent.  When notifications reach the GroupAdapter, it dispatches final change notifications.  There's never a need to manually notify or keep track of indices, no matter how you structure your data.
+Modifying the contents of a Group automatically notifies its parent.  When notifications reach the GroupieAdapter, it dispatches final change notifications.  There's never a need to manually notify or keep track of indices, no matter how you structure your data.
 
 ```java
 section.removeHeader(); // results in a remove event for 1 item in the adapter, at position 2
@@ -104,7 +104,7 @@ You can implement the `Group` interface directly if you want.  However, in most 
     
 ## Items
 
-Groupie abstracts away the complexity of multiple item view types.  Each Item declares a view layout id, and gets a callback to `bind` the inflated layout.  That's all you need; you can add your new item directly to a `GroupAdapter` and call it a day.
+Groupie abstracts away the complexity of multiple item view types.  Each Item declares a view layout id, and gets a callback to `bind` the inflated layout.  That's all you need; you can add your new item directly to a `GroupieAdapter` and call it a day.
 
 ### Item with Kotlin:
 

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/CarouselGroup.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/CarouselGroup.java
@@ -4,8 +4,8 @@ import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.xwray.groupie.Group;
-import com.xwray.groupie.GroupAdapter;
 import com.xwray.groupie.GroupDataObserver;
+import com.xwray.groupie.GroupieAdapter;
 import com.xwray.groupie.Item;
 import com.xwray.groupie.example.databinding.item.CarouselItem;
 
@@ -40,7 +40,7 @@ public class CarouselGroup implements Group {
         }
     };
 
-    public CarouselGroup(RecyclerView.ItemDecoration itemDecoration, GroupAdapter adapter) {
+    public CarouselGroup(RecyclerView.ItemDecoration itemDecoration, GroupieAdapter adapter) {
         this.adapter = adapter;
         carouselItem = new CarouselItem(itemDecoration, adapter);
         isEmpty = adapter.getItemCount() == 0;

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/MainActivity.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/MainActivity.java
@@ -16,7 +16,7 @@ import android.widget.Toast;
 
 import com.xwray.groupie.ExpandableGroup;
 import com.xwray.groupie.Group;
-import com.xwray.groupie.GroupAdapter;
+import com.xwray.groupie.GroupieAdapter;
 import com.xwray.groupie.Item;
 import com.xwray.groupie.OnItemClickListener;
 import com.xwray.groupie.OnItemLongClickListener;
@@ -50,7 +50,7 @@ public class MainActivity extends AppCompatActivity {
     public static final String INSET = "inset";
 
     private ActivityMainBinding binding;
-    private GroupAdapter groupAdapter;
+    private GroupieAdapter groupAdapter;
     private GridLayoutManager layoutManager;
     private Prefs prefs;
 
@@ -80,7 +80,7 @@ public class MainActivity extends AppCompatActivity {
         rainbow200 = getResources().getIntArray(R.array.rainbow_200);
         rainbow500 = getResources().getIntArray(R.array.rainbow_500);
 
-        groupAdapter = new GroupAdapter();
+        groupAdapter = new GroupieAdapter();
         groupAdapter.setOnItemClickListener(onItemClickListener);
         groupAdapter.setOnItemLongClickListener(onItemLongClickListener);
         groupAdapter.setSpanCount(12);
@@ -216,7 +216,7 @@ public class MainActivity extends AppCompatActivity {
 
     private Group makeCarouselGroup() {
         CarouselItemDecoration carouselDecoration = new CarouselItemDecoration(gray, betweenPadding);
-        GroupAdapter carouselAdapter = new GroupAdapter();
+        GroupieAdapter carouselAdapter = new GroupieAdapter();
         for (int i = 0; i < 10; i++) {
             carouselAdapter.add(new CarouselCardItem(rainbow200[i]));
         }

--- a/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselItem.java
+++ b/example-databinding/src/main/java/com/xwray/groupie/example/databinding/item/CarouselItem.java
@@ -5,7 +5,7 @@ import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 
-import com.xwray.groupie.GroupAdapter;
+import com.xwray.groupie.GroupieAdapter;
 import com.xwray.groupie.Item;
 import com.xwray.groupie.OnItemClickListener;
 import com.xwray.groupie.databinding.BindableItem;
@@ -18,10 +18,10 @@ import com.xwray.groupie.example.databinding.databinding.ItemCarouselBinding;
  */
 public class CarouselItem extends BindableItem<ItemCarouselBinding> implements OnItemClickListener {
 
-    private GroupAdapter adapter;
+    private GroupieAdapter adapter;
     private RecyclerView.ItemDecoration carouselDecoration;
 
-    public CarouselItem(RecyclerView.ItemDecoration itemDecoration, GroupAdapter adapter) {
+    public CarouselItem(RecyclerView.ItemDecoration itemDecoration, GroupieAdapter adapter) {
         this.carouselDecoration = itemDecoration;
         this.adapter = adapter;
         adapter.setOnItemClickListener(this);

--- a/example-viewbinding/src/main/java/com/xwray/groupie/example/viewbinding/CarouselGroup.kt
+++ b/example-viewbinding/src/main/java/com/xwray/groupie/example/viewbinding/CarouselGroup.kt
@@ -4,9 +4,8 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.AdapterDataObserver
 import androidx.recyclerview.widget.RecyclerView.ItemDecoration
 import com.xwray.groupie.Group
-import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.GroupieAdapter
 import com.xwray.groupie.GroupDataObserver
-import com.xwray.groupie.GroupieViewHolder
 import com.xwray.groupie.Item
 import com.xwray.groupie.example.viewbinding.item.CarouselItem
 
@@ -15,7 +14,7 @@ import com.xwray.groupie.example.viewbinding.item.CarouselItem
  */
 class CarouselGroup(
     itemDecoration: ItemDecoration,
-    adapter: GroupAdapter<GroupieViewHolder>
+    adapter: GroupieAdapter
 ) : Group {
 
     private var isEmpty = true

--- a/example-viewbinding/src/main/java/com/xwray/groupie/example/viewbinding/MainActivity.kt
+++ b/example-viewbinding/src/main/java/com/xwray/groupie/example/viewbinding/MainActivity.kt
@@ -13,8 +13,7 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import com.xwray.groupie.ExpandableGroup
 import com.xwray.groupie.Group
-import com.xwray.groupie.GroupAdapter
-import com.xwray.groupie.GroupieViewHolder
+import com.xwray.groupie.GroupieAdapter
 import com.xwray.groupie.OnItemClickListener
 import com.xwray.groupie.OnItemLongClickListener
 import com.xwray.groupie.Section
@@ -44,7 +43,7 @@ const val INSET = "inset"
 class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
-    private lateinit var groupAdapter: GroupAdapter<GroupieViewHolder>
+    private lateinit var groupAdapter: GroupieAdapter
     private lateinit var prefs: Prefs
 
     private val gray: Int by lazy { ContextCompat.getColor(this, R.color.background) }
@@ -66,7 +65,7 @@ class MainActivity : AppCompatActivity() {
 
         prefs = Prefs.get(this)
 
-        groupAdapter = GroupAdapter<GroupieViewHolder>().apply {
+        groupAdapter = GroupieAdapter().apply {
             setOnItemClickListener(onItemClickListener)
             setOnItemLongClickListener(onItemLongClickListener)
             spanCount = 12
@@ -192,7 +191,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun makeCarouselGroup(): Group {
         val carouselDecoration = CarouselItemDecoration(gray, betweenPadding)
-        val carouselAdapter = GroupAdapter<GroupieViewHolder>()
+        val carouselAdapter = GroupieAdapter()
         for (i in 0..9) {
             carouselAdapter.add(CarouselCardItem(rainbow200[i]))
         }

--- a/example-viewbinding/src/main/java/com/xwray/groupie/example/viewbinding/item/CarouselItem.kt
+++ b/example-viewbinding/src/main/java/com/xwray/groupie/example/viewbinding/item/CarouselItem.kt
@@ -3,7 +3,7 @@ package com.xwray.groupie.example.viewbinding.item
 import android.view.View
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView.ItemDecoration
-import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.GroupieAdapter
 import com.xwray.groupie.Item
 import com.xwray.groupie.OnItemClickListener
 import com.xwray.groupie.example.viewbinding.R
@@ -16,7 +16,7 @@ import com.xwray.groupie.viewbinding.GroupieViewHolder
  */
 class CarouselItem(
     private val carouselDecoration: ItemDecoration,
-    private val adapter: GroupAdapter<com.xwray.groupie.GroupieViewHolder>
+    private val adapter: GroupieAdapter
 ) : BindableItem<ItemCarouselBinding>(), OnItemClickListener {
 
     init {

--- a/example/src/main/java/com/xwray/groupie/example/MainActivity.kt
+++ b/example/src/main/java/com/xwray/groupie/example/MainActivity.kt
@@ -14,8 +14,7 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import com.xwray.groupie.ExpandableGroup
 import com.xwray.groupie.Group
-import com.xwray.groupie.GroupAdapter
-import com.xwray.groupie.GroupieViewHolder
+import com.xwray.groupie.GroupieAdapter
 import com.xwray.groupie.OnItemClickListener
 import com.xwray.groupie.OnItemLongClickListener
 import com.xwray.groupie.Section
@@ -34,7 +33,7 @@ const val INSET = "inset"
 
 class MainActivity : AppCompatActivity() {
 
-    private val groupAdapter = GroupAdapter<GroupieViewHolder>() //TODO get rid of this parameter
+    private val groupAdapter = GroupieAdapter()
     private lateinit var groupLayoutManager: GridLayoutManager
     private val prefs by lazy { Prefs.get(this) }
     private val handler = Handler()
@@ -329,7 +328,7 @@ class MainActivity : AppCompatActivity() {
 
     private fun makeCarouselItem(): CarouselItem {
         val carouselDecoration = CarouselItemDecoration(gray, betweenPadding)
-        val carouselAdapter = GroupAdapter<GroupieViewHolder>()
+        val carouselAdapter = GroupieAdapter()
         for (i in 0..29) {
             carouselAdapter += CarouselCardItem(rainbow200[7])
         }

--- a/example/src/main/java/com/xwray/groupie/example/item/CarouselItem.kt
+++ b/example/src/main/java/com/xwray/groupie/example/item/CarouselItem.kt
@@ -2,7 +2,7 @@ package com.xwray.groupie.example.item
 
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.xwray.groupie.GroupAdapter
+import com.xwray.groupie.GroupieAdapter
 import com.xwray.groupie.example.R
 import com.xwray.groupie.kotlinandroidextensions.Item
 import com.xwray.groupie.kotlinandroidextensions.GroupieViewHolder
@@ -12,7 +12,7 @@ import kotlinx.android.synthetic.main.item_carousel.*
  * A horizontally scrolling RecyclerView, for use in a vertically scrolling RecyclerView.
  */
 class CarouselItem(private val carouselDecoration: RecyclerView.ItemDecoration,
-                   private val carouselAdapter: GroupAdapter<com.xwray.groupie.GroupieViewHolder>) : Item() {
+                   private val carouselAdapter: GroupieAdapter) : Item() {
 
     override fun getLayout(): Int {
         return R.layout.item_carousel

--- a/library/src/main/java/com/xwray/groupie/GroupieAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupieAdapter.java
@@ -1,0 +1,4 @@
+package com.xwray.groupie;
+
+public class GroupieAdapter extends GroupAdapter<GroupieViewHolder> {
+}


### PR DESCRIPTION
Implement the following ToDo: `GroupAdapter<GroupieViewHolder>() //TODO get rid of this parameter`
Basically `GroupieAdapter` extends from `GroupAdapter` using `GroupieViewHolder`. This way it's backward compatible and allow us to get rid of the generic parameter in kotlin. @lisawray what do you think?