### PR TITLE
Diffutils rework

### DIFF
--- a/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/GroupAdapterExt.kt
+++ b/library-kotlin-android-extensions/src/main/java/com/xwray/groupie/groupiex/GroupAdapterExt.kt
@@ -6,6 +6,6 @@ import com.xwray.groupie.GroupieViewHolder
 
 // TODO(zhuinden): move this into its own artifact later: `groupiex` (or rather, `groupie-ktx`)
 operator fun GroupAdapter<out GroupieViewHolder>.plusAssign(element: Group) = this.add(element)
-operator fun GroupAdapter<out GroupieViewHolder>.plusAssign(groups: Collection<Group>) = this.addAll(groups)
+operator fun GroupAdapter<out GroupieViewHolder>.plusAssign(groups: List<Group>) = this.addAll(groups)
 operator fun GroupAdapter<out GroupieViewHolder>.minusAssign(element: Group) = this.remove(element)
-operator fun GroupAdapter<out GroupieViewHolder>.minusAssign(groups: Collection<Group>)  = this.removeAll(groups)
+operator fun GroupAdapter<out GroupieViewHolder>.minusAssign(groups: List<Group>)  = this.removeAll(groups)

--- a/library/src/main/java/com/xwray/groupie/AsyncDiffUtil.java
+++ b/library/src/main/java/com/xwray/groupie/AsyncDiffUtil.java
@@ -1,54 +1,107 @@
 package com.xwray.groupie;
 
-import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.ListUpdateCallback;
 
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * A wrapper around {@link DiffUtil} that calculates diff in a background thread
  */
-class AsyncDiffUtil {
+class AsyncDiffUtil implements ListUpdateCallback, OnAsyncUpdateListener {
+
     interface Callback extends ListUpdateCallback {
-        /**
-         * Called on the main thread before DiffUtil dispatches the result
-         */
-        @MainThread
-        void onDispatchAsyncResult(@NonNull Collection<? extends Group> newGroups);
+        void onUpdateComplete(List<Group> groups);
     }
 
     private final Callback asyncDiffUtilCallback;
     private int maxScheduledGeneration;
-    private Collection<? extends Group> groups;
+    private List<Group> newGroupList;
+    private List<Group> resultGroups;
 
     AsyncDiffUtil(@NonNull Callback callback) {
         this.asyncDiffUtilCallback = callback;
     }
 
-    @NonNull
-    Callback getAsyncDiffUtilCallback() {
-        return asyncDiffUtilCallback;
+    @Override
+    public void onInserted(int position, int count) {
+        List<Group> groupList = newGroupList.subList(position, position + count);
+        resultGroups.addAll(position, groupList);
+
+        asyncDiffUtilCallback.onInserted(position, count);
+    }
+
+    @Override
+    public void onRemoved(int position, int count) {
+        List<Group> subList = resultGroups.subList(position, position + count);
+        resultGroups.removeAll(subList);
+
+        asyncDiffUtilCallback.onRemoved(position, count);
+    }
+
+    @Override
+    public void onMoved(int fromPosition, int toPosition) {
+        resultGroups.remove(fromPosition);
+        Group group = newGroupList.get(toPosition);
+        resultGroups.add(toPosition, group);
+
+        asyncDiffUtilCallback.onMoved(fromPosition, toPosition);
+    }
+
+    @Override
+    public void onChanged(int position, int count, @Nullable Object payload) {
+        List<Group> subList = resultGroups.subList(position, position + count);
+        resultGroups.removeAll(subList);
+        List<Group> newSubList = newGroupList.subList(position, position + count);
+        resultGroups.addAll(position, newSubList);
+
+        asyncDiffUtilCallback.onChanged(position, count, payload);
+    }
+
+    @Override
+    public void onUpdateComplete() {
+        List<Group> groups = this.resultGroups;
+        newGroupList = null;
+        resultGroups = null;
+        asyncDiffUtilCallback.onUpdateComplete(groups);
     }
 
     @NonNull
-    Collection<? extends Group> getGroups() {
-        return groups;
+    ListUpdateCallback getAsyncDiffUtilCallback() {
+        return asyncDiffUtilCallback;
     }
 
     int getMaxScheduledGeneration() {
         return maxScheduledGeneration;
     }
 
-    void calculateDiff(@NonNull Collection<? extends Group> newGroups,
+    void calculateDiff(@NonNull Collection<Group> oldGroups,
+                       @NonNull Collection<Group> newGroups,
                        @NonNull DiffUtil.Callback diffUtilCallback,
-                       @Nullable OnAsyncUpdateListener onAsyncUpdateListener,
+                       @Nullable final OnAsyncUpdateListener onAsyncUpdateListener,
                        boolean detectMoves) {
-        groups = newGroups;
+        newGroupList = new ArrayList<>(newGroups);
+        resultGroups = new ArrayList<>(oldGroups);
         // incrementing generation means any currently-running diffs are discarded when they finish
         final int runGeneration = ++maxScheduledGeneration;
-        new DiffTask(this, diffUtilCallback, runGeneration, detectMoves, onAsyncUpdateListener).execute();
+        new DiffTask(this, diffUtilCallback, runGeneration, detectMoves, mergeListener(onAsyncUpdateListener)).execute();
+    }
+
+    private OnAsyncUpdateListener mergeListener(@Nullable final OnAsyncUpdateListener onAsyncUpdateListener) {
+        final WeakReference<OnAsyncUpdateListener> listenerWeakReference = new WeakReference<OnAsyncUpdateListener>(this);
+
+        return new OnAsyncUpdateListener() {
+
+            @Override
+            public void onUpdateComplete() {
+                listenerWeakReference.get().onUpdateComplete();
+                onAsyncUpdateListener.onUpdateComplete();
+            }
+        };
     }
 }

--- a/library/src/main/java/com/xwray/groupie/AsyncDiffUtil.java
+++ b/library/src/main/java/com/xwray/groupie/AsyncDiffUtil.java
@@ -1,107 +1,44 @@
 package com.xwray.groupie;
 
+import androidx.annotation.MainThread;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.ListUpdateCallback;
 
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
  * A wrapper around {@link DiffUtil} that calculates diff in a background thread
  */
-class AsyncDiffUtil implements ListUpdateCallback, OnAsyncUpdateListener {
+class AsyncDiffUtil {
 
     interface Callback extends ListUpdateCallback {
-        void onUpdateComplete(List<Group> groups);
+        /**
+         * Called on the main thread before DiffUtil dispatches the result
+         */
+        @MainThread
+        void onDispatchAsyncResult(List<Group> mergedGroups);
     }
 
-    private final Callback asyncDiffUtilCallback;
+    final Callback asyncDiffUtilCallback;
     private int maxScheduledGeneration;
-    private List<Group> newGroupList;
-    private List<Group> resultGroups;
 
     AsyncDiffUtil(@NonNull Callback callback) {
         this.asyncDiffUtilCallback = callback;
-    }
-
-    @Override
-    public void onInserted(int position, int count) {
-        List<Group> groupList = newGroupList.subList(position, position + count);
-        resultGroups.addAll(position, groupList);
-
-        asyncDiffUtilCallback.onInserted(position, count);
-    }
-
-    @Override
-    public void onRemoved(int position, int count) {
-        List<Group> subList = resultGroups.subList(position, position + count);
-        resultGroups.removeAll(subList);
-
-        asyncDiffUtilCallback.onRemoved(position, count);
-    }
-
-    @Override
-    public void onMoved(int fromPosition, int toPosition) {
-        resultGroups.remove(fromPosition);
-        Group group = newGroupList.get(toPosition);
-        resultGroups.add(toPosition, group);
-
-        asyncDiffUtilCallback.onMoved(fromPosition, toPosition);
-    }
-
-    @Override
-    public void onChanged(int position, int count, @Nullable Object payload) {
-        List<Group> subList = resultGroups.subList(position, position + count);
-        resultGroups.removeAll(subList);
-        List<Group> newSubList = newGroupList.subList(position, position + count);
-        resultGroups.addAll(position, newSubList);
-
-        asyncDiffUtilCallback.onChanged(position, count, payload);
-    }
-
-    @Override
-    public void onUpdateComplete() {
-        List<Group> groups = this.resultGroups;
-        newGroupList = null;
-        resultGroups = null;
-        asyncDiffUtilCallback.onUpdateComplete(groups);
-    }
-
-    @NonNull
-    ListUpdateCallback getAsyncDiffUtilCallback() {
-        return asyncDiffUtilCallback;
     }
 
     int getMaxScheduledGeneration() {
         return maxScheduledGeneration;
     }
 
-    void calculateDiff(@NonNull Collection<Group> oldGroups,
-                       @NonNull Collection<Group> newGroups,
-                       @NonNull DiffUtil.Callback diffUtilCallback,
+    void calculateDiff(@NonNull List<? extends Group> oldGroups,
+                       @NonNull List<? extends Group> newGroups,
                        @Nullable final OnAsyncUpdateListener onAsyncUpdateListener,
                        boolean detectMoves) {
-        newGroupList = new ArrayList<>(newGroups);
-        resultGroups = new ArrayList<>(oldGroups);
         // incrementing generation means any currently-running diffs are discarded when they finish
         final int runGeneration = ++maxScheduledGeneration;
-        new DiffTask(this, diffUtilCallback, runGeneration, detectMoves, mergeListener(onAsyncUpdateListener)).execute();
-    }
-
-    private OnAsyncUpdateListener mergeListener(@Nullable final OnAsyncUpdateListener onAsyncUpdateListener) {
-        final WeakReference<OnAsyncUpdateListener> listenerWeakReference = new WeakReference<OnAsyncUpdateListener>(this);
-
-        return new OnAsyncUpdateListener() {
-
-            @Override
-            public void onUpdateComplete() {
-                listenerWeakReference.get().onUpdateComplete();
-                onAsyncUpdateListener.onUpdateComplete();
-            }
-        };
+        final DiffCallback diffUtilCallback = new DiffCallback(oldGroups, newGroups);
+        new DiffTask(this, diffUtilCallback, runGeneration, detectMoves, onAsyncUpdateListener).execute();
     }
 }

--- a/library/src/main/java/com/xwray/groupie/DiffTask.java
+++ b/library/src/main/java/com/xwray/groupie/DiffTask.java
@@ -1,6 +1,7 @@
 package com.xwray.groupie;
 
 import android.os.AsyncTask;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.DiffUtil;
@@ -10,17 +11,17 @@ import java.util.Collection;
 
 /**
  * An async task implementation that runs {@link DiffUtil#calculateDiff(DiffUtil.Callback)}
- * in a background thread. This task will call {@link AsyncDiffUtil.Callback#onDispatchAsyncResult(Collection)}
- * passing the new list just before dispatching the diff result to the provided
- * {@link DiffUtil.Callback} so that the new list.
- * <p>This task is executed via {@link AsyncDiffUtil#calculateDiff(Collection, DiffUtil.Callback, OnAsyncUpdateListener, boolean)}.
+ * in a background thread.
+ * <p>This task is executed via {@link AsyncDiffUtil#calculateDiff(Collection, Collection, DiffUtil.Callback, OnAsyncUpdateListener, boolean)}.
  */
 class DiffTask extends AsyncTask<Void, Void, DiffUtil.DiffResult> {
-    @NonNull private final DiffUtil.Callback diffCallback;
+    @NonNull
+    private final DiffUtil.Callback diffCallback;
     private final WeakReference<AsyncDiffUtil> asyncListDiffer;
     private final int runGeneration;
     private final boolean detectMoves;
-    @Nullable private WeakReference<OnAsyncUpdateListener> onAsyncUpdateListener;
+    @Nullable
+    private WeakReference<OnAsyncUpdateListener> onAsyncUpdateListener;
     private Exception backgroundException = null;
 
     DiffTask(@NonNull AsyncDiffUtil asyncDiffUtil,
@@ -55,7 +56,6 @@ class DiffTask extends AsyncTask<Void, Void, DiffUtil.DiffResult> {
         }
         AsyncDiffUtil async = asyncListDiffer.get();
         if (shouldDispatchResult(diffResult, async)) {
-            async.getAsyncDiffUtilCallback().onDispatchAsyncResult(async.getGroups());
             diffResult.dispatchUpdatesTo(async.getAsyncDiffUtilCallback());
             if (onAsyncUpdateListener != null && onAsyncUpdateListener.get() != null) {
                 onAsyncUpdateListener.get().onUpdateComplete();

--- a/library/src/main/java/com/xwray/groupie/GroupAdapter.java
+++ b/library/src/main/java/com/xwray/groupie/GroupAdapter.java
@@ -8,6 +8,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.DiffUtil;
 import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.ListUpdateCallback;
 import androidx.recyclerview.widget.RecyclerView;
 
 import java.util.ArrayList;
@@ -27,8 +28,8 @@ public class GroupAdapter<VH extends GroupieViewHolder> extends RecyclerView.Ada
 
     private AsyncDiffUtil.Callback diffUtilCallbacks = new AsyncDiffUtil.Callback() {
         @Override
-        public void onDispatchAsyncResult(@NonNull Collection<? extends Group> newGroups) {
-            setNewGroups(newGroups);
+        public void onUpdateComplete(List<Group> groups) {
+            setNewGroups(groups);
         }
 
         @Override
@@ -95,7 +96,7 @@ public class GroupAdapter<VH extends GroupieViewHolder> extends RecyclerView.Ada
      * @param newGroups List of {@link Group}
      */
     @SuppressWarnings("unused")
-    public void updateAsync(@NonNull final List<? extends Group> newGroups) {
+    public void updateAsync(@NonNull final List<Group> newGroups) {
         this.updateAsync(newGroups, true, null);
     }
 
@@ -114,7 +115,7 @@ public class GroupAdapter<VH extends GroupieViewHolder> extends RecyclerView.Ada
      * @param newGroups List of {@link Group}
      */
     @SuppressWarnings("unused")
-    public void updateAsync(@NonNull final List<? extends Group> newGroups, @Nullable final OnAsyncUpdateListener onAsyncUpdateListener) {
+    public void updateAsync(@NonNull final List<Group> newGroups, @Nullable final OnAsyncUpdateListener onAsyncUpdateListener) {
         this.updateAsync(newGroups, true, onAsyncUpdateListener);
     }
 
@@ -132,7 +133,7 @@ public class GroupAdapter<VH extends GroupieViewHolder> extends RecyclerView.Ada
      *                    if you want DiffUtil to detect moved items.
      */
     @SuppressWarnings("unused")
-    public void updateAsync(@NonNull final List<? extends Group> newGroups, boolean detectMoves, @Nullable final OnAsyncUpdateListener onAsyncUpdateListener) {
+    public void updateAsync(@NonNull final List<Group> newGroups, boolean detectMoves, @Nullable final OnAsyncUpdateListener onAsyncUpdateListener) {
         // Fast simple first insert
         if (groups.isEmpty()) {
             update(newGroups, detectMoves);
@@ -144,7 +145,7 @@ public class GroupAdapter<VH extends GroupieViewHolder> extends RecyclerView.Ada
         final List<Group> oldGroups = new ArrayList<>(groups);
 
         final DiffCallback diffUtilCallback = new DiffCallback(oldGroups, newGroups);
-        asyncDiffUtil.calculateDiff(newGroups, diffUtilCallback, onAsyncUpdateListener, detectMoves);
+        asyncDiffUtil.calculateDiff(oldGroups, newGroups, diffUtilCallback, onAsyncUpdateListener, detectMoves);
     }
 
     /**
@@ -187,8 +188,6 @@ public class GroupAdapter<VH extends GroupieViewHolder> extends RecyclerView.Ada
                 new DiffCallback(oldGroups, newGroups),
                 detectMoves
         );
-
-        setNewGroups(newGroups);
 
         diffResult.dispatchUpdatesTo(diffUtilCallbacks);
     }

--- a/library/src/main/java/com/xwray/groupie/GroupUtils.java
+++ b/library/src/main/java/com/xwray/groupie/GroupUtils.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 
 class GroupUtils {
     @NonNull
-    static Item getItem(Collection<? extends Group> groups, int position) {
+    static Item getItem(Collection<? extends Group> groups, int position) throws IndexOutOfBoundsException {
         int previousPosition = 0;
 
         for (Group group : groups) {


### PR DESCRIPTION
I finded problem, that after diffutils work, we just take new groups, but actually not all new groups will be settet do RecyclerView. 
Major problem is that we unregister all old groups from adapter, but he can be still used by RecyclerView. 
U can see it, if update items by method _updateAsync_ and try to use _notifyChanged_.