### PR TITLE
upgrade Kotlin to version 1.5.32

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ In your project level `build.gradle` file, include:
 
 ```
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.5.32'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ def testResultsDir = "${rootProject.buildDir}/test-results"
 
 buildscript {
 
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.5.32'
     ext.android_plugin_version = '4.1.1'
     ext.sdkVersion = 29
     ext.minimumSdkVersion = 14


### PR DESCRIPTION
1.4.21 is over a year old and 1.6 is already released, this seemed like a good compromise.
However.. I'm unsure of what impact this would have on the deprecations noted i.e. `kotlin-android-extensions`