### PR TITLE
Upgrade Junit to fix issue #433

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
     ext.databinding_version = '7.1.3'
     ext.viewbinding_version = '7.1.3'
 
-    ext.junit_version = '4.13'
+    ext.junit_version = '4.13.2'
     ext.mockito_version = '3.3.3'
 
     repositories {


### PR DESCRIPTION
Upgrading Junit because 4.13 has known vulnerabilities

Builds are failing due to this error

> Could not find com.xwray:groupie:2.9.0.
     Required by:
         *******************
 > Could not find com.xwray:groupie-viewbinding:2.9.0.
     Required by:
         *******************

Which leads me to this vulnerability found:
https://mvnrepository.com/artifact/com.xwray/groupie/2.9.0
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15250

Upgrading to 4.13.1 is needed at the least