### PR TITLE
Enabling LiveData to update dynamically within bindable items

### DIFF
--- a/library-databinding/build.gradle
+++ b/library-databinding/build.gradle
@@ -31,6 +31,7 @@ android {
 dependencies {
     implementation project(':library')
     implementation "androidx.recyclerview:recyclerview:1.2.1"
+    implementation "androidx.lifecycle:lifecycle-runtime:2.5.1"
     compileOnly("androidx.databinding:databinding-runtime:$databinding_version") {
         transitive = false
     }

--- a/library-databinding/src/main/java/com/xwray/groupie/databinding/BindableItem.java
+++ b/library-databinding/src/main/java/com/xwray/groupie/databinding/BindableItem.java
@@ -4,6 +4,7 @@ import androidx.databinding.DataBindingUtil;
 import androidx.databinding.ViewDataBinding;
 import androidx.annotation.CallSuper;
 import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewTreeLifecycleOwner;
 import android.view.View;
 
 import com.xwray.groupie.Item;
@@ -86,5 +87,11 @@ public abstract class BindableItem<T extends ViewDataBinding> extends Item<Group
      */
     public void bind(@NonNull T viewBinding, int position, @NonNull List<Object> payloads) {
         bind(viewBinding, position);
+    }
+
+    @Override
+    public void onViewAttachedToWindow(@NonNull GroupieViewHolder<T> viewHolder) {
+        super.onViewAttachedToWindow(viewHolder);
+        viewHolder.binding.setLifecycleOwner(ViewTreeLifecycleOwner.get(viewHolder.binding.getRoot()));
     }
 }


### PR DESCRIPTION
Android needs a lifecycle object in order for android to update properties from changing LiveData and/or Kotlin StateFlows. setting this value has no effect if no reactive objects are used. 

By setting this bindable items will properly react to dynamic changes in text, color, and properly call any custom defined binding extension. 